### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bitcoin SV MCP Server
 
-[![smithery badge](https://smithery.ai/badge/@b-open-io/bsv-mcp)](https://smithery.ai/server/@b-open-io/bsv-mcp)
+[![LightNow capabilities](https://lightnow.ai/badge/io.github.b-open-io/bsv-mcp)](https://lightnow.ai/servers/io.github.b-open-io/bsv-mcp)
 
 > **⚠️ NOTICE: Experimental Work in Progress**  
 > This project is in an early experimental stage. Features may change, and the API is not yet stable.


### PR DESCRIPTION
Replaces the broken Smithery badge with the LightNow capability badge.

- [LightNow entry](https://lightnow.ai/servers/io.github.b-open-io/bsv-mcp)
- [Badge variants and usage](https://docs.lightnow.ai/how-to/add-capability-badge/)

Validated as a valid SVG showing `75 T · 107 R · 8 P`; the linked listing resolves successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791112298&installation_model_id=435537&pr_number=6&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F6&signature=417f23d401589137889be26f42df8919081560a69e5cb152181af9d0a447f4f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->