### PR TITLE
Connect existing BRC100 signers and add sponsored operations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "bsv-mcp",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Bitcoin SV MCP server with interactive dashboard — Explorer, Wallet, and Ordinals tabs via MCP Apps. Tools for price lookup, transaction decoding, address lookup, wallet management, NFT marketplace, and identity.",
 	"author": {
 		"name": "rohenaz",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # BSV MCP Server Changelog
 
+## [0.3.1] - 2026-09-05
+
+### Added
+- Connect an existing BRC-100 HTTP signer without loading local private keys or provisioning wallet storage.
+- Inspect sponsor access and submit sponsored push/fund operations with the connected signer.
+
+### Fixed
+- Preserve wallet permission arguments through MCP schemas.
+- Block automatic HTTP payment during sponsor authentication and avoid ambiguous write retries.
+- Preserve explicitly requested satoshi amounts in legacy Droplit taps.
+
 ## [0.3.0] - 2026-07-30
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -8,6 +8,51 @@
 
 A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework. This library provides wallet, ordinals, and utility functions for BSV blockchain interaction.
 
+## Connect an existing BRC-100 signer
+
+Set `BRC100_WALLET_URL` to explicitly use an existing wallet through the SDK's
+`HTTPWalletJSON` signer RPC transport. For example, **if your wallet already
+exposes this signer RPC**:
+
+```bash
+BRC100_WALLET_URL=http://127.0.0.1:3321 BRC100_WALLET_ORIGINATOR=bsv-mcp.local bun run index.ts --stdio
+```
+
+`BRC100_WALLET_ORIGINATOR` is optional and defaults to `bsv-mcp.local`; use a
+domain or HTTP(S) origin without credentials, paths, queries or fragments.
+Empty, malformed and `admin.bsv-mcp.internal` origins are rejected. The SDK
+sends the origin as both `Origin` and `Originator` headers in Node/Bun.
+Signer URLs must use HTTPS, or HTTP on loopback (`localhost`, `127.0.0.0/8`,
+`[::1]`), without credentials, queries or fragments. Redirects are rejected.
+
+Remove `PRIVATE_KEY_WIF`, `IDENTITY_KEY_WIF`, `DROPLIT_API_URL` and
+`DROPLIT_FAUCET_NAME`, and disable `USE_DROPLIT_API` before enabling this mode:
+explicit conflicting configuration is rejected. Existing local key files are
+left unread. This mode generates no keys, creates no local wallet or storage,
+and provisions no remote storage. Startup performs one identity-public-key
+request with a 10-second timeout. Failure stops startup with a nonzero exit;
+there is no endpoint probing or identity fallback. All signer calls have a
+10-second timeout and no automatic retries; a timed-out write may have reached
+the signer, so inspect its state before resubmitting.
+
+The external wallet remains the permission authority, including spending and
+identity disclosure. Tool arguments (including `seekPermission`) reach it
+without a permission-bypass wrapper or automatic approval. Approve requests
+in your wallet. MCP shutdown does not shut down the signer.
+
+Context wallet/BRC-100 tools are available without a legacy wallet. Legacy
+collection minting/gathering, A2B publication, BAP/raw-key, BSocial and MNEE
+tools are unavailable in this mode. `BSV_CHAIN` selects `main` (default) or
+`test`. Existing `ONESAT_API_URL` configures the auxiliary OneSat API clients
+used by context actions; it is separate from the signer URL. Those actions
+still require the corresponding OneSat service capabilities and the signer's
+support for the requested protocol/baskets. Existing tool disable flags apply.
+
+**Transport distinction:** `1sat serve wallet` exposes **storage RPC**, not
+the SDK signer RPC. Do not set `BRC100_WALLET_URL` to that storage endpoint.
+This server does not start or supply a signer daemon. Without
+`BRC100_WALLET_URL`, the existing local wallet configuration remains in effect.
+
 ## Installation Options
 
 ### Option 1: Claude Code Plugin (Simplest)
@@ -830,3 +875,40 @@ npm test
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+
+### Use a sponsor with your connected wallet
+
+```sh
+BRC100_WALLET_URL=http://127.0.0.1:3321
+BRC100_WALLET_ORIGINATOR=bsv-mcp.local
+DROPLIT_API_URL=https://api.droplit.dev/droplit
+DROPLIT_FAUCET_NAME=your-sponsor-slug
+```
+
+Set both sponsor values explicitly. The URL includes the server's configured
+base path. Leave `USE_DROPLIT_API` unset: these sponsor tools appear alongside
+normal wallet tools and use the same connected signer identity. Existing local
+BRC-100 wallet contexts also support this sponsor pair. `1sat serve` exposes a
+wallet stack service; it is not itself a BRC-100 signer RPC endpoint.
+
+Call `droplit_getAccess` to inspect your own authorization and quotas. An
+`approval_required` response includes a `https://droplit.dev` link for manual
+owner review. Do not automatically open, approve, or register to obtain access.
+Public status and public-key registration do not prove sponsor approval, and
+creating your own faucet requires funding rather than providing free credit.
+Missing quota kinds are unrestricted for authorized users; a configured zero
+count remains denied. Count and transfer quotas exclude a guaranteed miner-fee
+budget.
+
+`droplit_push` accepts `data: string[]` and `encoding: "hex" | "utf8"`.
+`droplit_fund` accepts `rawtx` transaction hex and requests sponsor funding and
+broadcast. Both obey broadcasting disable settings and make one client
+submission, with no automatic 402 payment or ambiguous-write retry. Wallet
+signing permissions remain controlled by the configured signer. The API authentication
+facade forwards signer methods but rejects payment creation/signing, so SDK
+BRC-105 payment handling cannot spend funds; a 402 requires human review. Structured
+401/403/429 errors identify authentication, approval, or quota problems;
+available quota reset information is retained. `unknown_outcome` means reconcile
+transaction/history before retrying; no idempotency-key support is claimed.
+The legacy `USE_DROPLIT_API=true` wallet mode remains available separately.

--- a/dist/index.js
+++ b/dist/index.js
@@ -223156,7 +223156,7 @@ var require_timestamp2 = __commonJS((exports, module) => {
 
 // node_modules/knex/lib/migrations/migrate/MigrationGenerator.js
 var require_MigrationGenerator = __commonJS((exports, module) => {
-  var __dirname = "/Users/satchmo/code/bsv-mcp/node_modules/knex/lib/migrations/migrate";
+  var __dirname = "/Users/satchmo/.codex/worktrees/agent-stack-mcp/node_modules/knex/lib/migrations/migrate";
   var path6 = __require("path");
   var { writeJsFileUsingTemplate } = require_template2();
   var { getMergedConfig } = require_migrator_configuration_merger();
@@ -223863,7 +223863,7 @@ var require_seeder_configuration_merger = __commonJS((exports, module) => {
 
 // node_modules/knex/lib/migrations/seed/Seeder.js
 var require_Seeder = __commonJS((exports, module) => {
-  var __dirname = "/Users/satchmo/code/bsv-mcp/node_modules/knex/lib/migrations/seed";
+  var __dirname = "/Users/satchmo/.codex/worktrees/agent-stack-mcp/node_modules/knex/lib/migrations/seed";
   var path6 = __require("path");
   var { ensureDirectoryExists } = require_fs();
   var { writeJsFileUsingTemplate } = require_template2();
@@ -256042,7 +256042,7 @@ var package_default = {
   name: "bsv-mcp",
   module: "dist/index.js",
   type: "module",
-  version: "0.3.0",
+  version: "0.3.1",
   license: "MIT",
   author: "satchmo",
   description: "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",
@@ -284875,6 +284875,281 @@ function registerUtilsTools(server) {
   });
 }
 
+// utils/droplit.ts
+init_mod2();
+class DroplitError extends Error {
+  code;
+  status;
+  details;
+  constructor(code, message, status, details = {}) {
+    super(message);
+    this.code = code;
+    this.status = status;
+    this.details = details;
+  }
+}
+function quotaDetails(body) {
+  if (!body || typeof body !== "object")
+    return {};
+  const value2 = body;
+  return {
+    ...typeof value2.remaining === "number" || value2.remaining === null ? { remaining: value2.remaining } : {},
+    ...typeof value2.resets_at === "string" ? { resets_at: value2.resets_at } : {}
+  };
+}
+function httpFailure(status, details = {}) {
+  const known = {
+    401: [
+      "authentication_required",
+      "Authenticate with the configured wallet before retrying."
+    ],
+    402: [
+      "approval_required",
+      "Payment is required. No automatic payment was made; review payment with the wallet owner."
+    ],
+    403: [
+      "approval_required",
+      "The sponsor has not authorized this action. Ask its owner to approve your wallet."
+    ],
+    429: [
+      "quota_exceeded",
+      "Sponsor quota exhausted. Wait until resets_at or ask the owner to adjust your quota."
+    ]
+  };
+  const [code, message] = known[status] ?? [
+    "http_error",
+    "Droplit rejected the request. Check sponsor access and transaction history before retrying."
+  ];
+  return new DroplitError(code, message, status, details);
+}
+
+class DroplitClient {
+  config;
+  authFetch;
+  wallet;
+  constructor(config2) {
+    this.config = config2;
+    if (config2.wallet && config2.authKey)
+      throw new Error("Configure Droplit wallet or authKey, not both");
+    const url3 = new URL(config2.apiUrl);
+    const loopback = url3.hostname === "localhost" || url3.hostname === "127.0.0.1" || url3.hostname === "[::1]";
+    if (url3.username || url3.password || url3.search || url3.hash || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
+      throw new Error("Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment");
+    }
+    if (!config2.faucetName.trim())
+      throw new Error("Droplit faucet name is required");
+    this.wallet = config2.wallet ?? (config2.authKey ? new ProtoWallet_default(config2.authKey) : undefined);
+    if (this.wallet) {
+      const authenticationWallet = new Proxy(this.wallet, {
+        get(target, property) {
+          if (property === "createAction" || property === "signAction") {
+            return async () => {
+              throw httpFailure(402);
+            };
+          }
+          const value2 = Reflect.get(target, property, target);
+          return typeof value2 === "function" ? value2.bind(target) : value2;
+        }
+      });
+      this.authFetch = new AuthFetch(authenticationWallet);
+    }
+  }
+  getConfig() {
+    return { apiUrl: this.config.apiUrl, faucetName: this.config.faucetName };
+  }
+  async getIdentityKey() {
+    if (!this.wallet)
+      throw new DroplitError("authentication_required", "Configure a Droplit wallet identity.");
+    const { publicKey } = await this.wallet.getPublicKey({ identityKey: true });
+    return publicKey;
+  }
+  get faucetPath() {
+    return `/faucet/${encodeURIComponent(this.config.faucetName)}`;
+  }
+  get base() {
+    return this.config.apiUrl.replace(/\/+$/, "");
+  }
+  async authed(path3, init) {
+    if (!this.authFetch) {
+      throw new Error(`${path3} requires authentication and no Droplit auth key is configured.`);
+    }
+    try {
+      return await this.authFetch.fetch(`${this.base}${path3}`, {
+        method: init.method,
+        headers: { "Content-Type": "application/json" },
+        ...init.body === undefined ? {} : { body: JSON.stringify(init.body) },
+        paymentRetryAttempts: 0,
+        ...init.method === "GET" || init.method === "HEAD" ? {} : { retryCounter: 1 }
+      });
+    } catch (error52) {
+      if (error52 instanceof DroplitError)
+        throw error52;
+      const details = error52?.details;
+      const status = details?.status;
+      if (typeof status === "number" && [401, 402, 403, 429].includes(status)) {
+        let body;
+        if (status === 429 && typeof details?.bodyPreview === "string") {
+          try {
+            body = JSON.parse(details.bodyPreview);
+          } catch {}
+        }
+        throw httpFailure(status, status === 429 ? quotaDetails(body) : {});
+      }
+      const write = init.method !== "GET" && init.method !== "HEAD";
+      throw new DroplitError(write ? "unknown_outcome" : "request_failed", write ? "Request outcome is unknown. Reconcile transaction/history before retrying; no automatic retry was made." : "Authenticated request failed. Check the signer and sponsor connection.");
+    }
+  }
+  async parse(response, _attempted) {
+    if (response.ok) {
+      try {
+        return await response.json();
+      } catch {
+        throw new DroplitError("unknown_outcome", "Response could not be read. Reconcile transaction/history before retrying.", response.status);
+      }
+    }
+    let body = {};
+    try {
+      body = await response.json();
+    } catch {}
+    throw httpFailure(response.status, response.status === 429 ? quotaDetails(body) : {});
+  }
+  async getAccess() {
+    const response = await this.authed(`${this.faucetPath}/access`, {
+      method: "GET"
+    });
+    const access = await this.parse(response, "Reading sponsor access");
+    const identity6 = await this.getIdentityKey();
+    if (!access || access.public_key !== identity6 || access.slug !== this.config.faucetName || typeof access.authorized !== "boolean" || typeof access.is_owner !== "boolean" || !Array.isArray(access.quotas) || !Array.isArray(access.unrestricted_kinds)) {
+      throw new DroplitError("invalid_response", "Sponsor access response did not match the authenticated wallet.");
+    }
+    access.approval_path = `/droplit/${encodeURIComponent(this.config.faucetName)}?tab=api&request_key=${encodeURIComponent(identity6)}`;
+    return access;
+  }
+  async fund(rawtx) {
+    const response = await this.authed(`${this.faucetPath}/fund`, {
+      method: "POST",
+      body: { rawtx }
+    });
+    return this.parse(response, "Funding transaction");
+  }
+  async getFaucetStatus() {
+    const response = await fetch(`${this.base}${this.faucetPath}/status`);
+    return this.parse(response, "Reading the faucet status");
+  }
+  async tap(recipientAddress, satoshis) {
+    if (satoshis !== undefined && (!Number.isSafeInteger(satoshis) || satoshis <= 0))
+      throw new Error("satoshis must be a positive safe integer");
+    const response = await this.authed(`${this.faucetPath}/tap`, {
+      method: "POST",
+      body: {
+        recipient_address: recipientAddress,
+        ...satoshis === undefined ? {} : { satoshis }
+      }
+    });
+    return this.parse(response, "Tapping the faucet");
+  }
+  async push(data, encoding = "hex") {
+    const response = await this.authed(`${this.faucetPath}/push`, {
+      method: "POST",
+      body: { data, encoding }
+    });
+    return this.parse(response, "Pushing data");
+  }
+  async authenticatedFetch(path3, init) {
+    return this.authed(path3, init);
+  }
+}
+
+// tools/wallet/droplit.ts
+function errorResult(error52) {
+  const failure = error52 instanceof DroplitError ? error52 : new DroplitError("request_failed", "Droplit operation failed. Check configuration and broadcasting policy.");
+  const data = {
+    error: failure.code,
+    message: failure.message,
+    ...failure.status === undefined ? {} : { status: failure.status },
+    ...failure.details
+  };
+  return {
+    ...createSuccessResponse(data),
+    structuredContent: data,
+    isError: true
+  };
+}
+function registerDroplitTools(server, client, disableBroadcasting = false) {
+  server.registerTool("droplit_getAccess", {
+    description: "Read this connected wallet's sponsor authorization and quotas. If unauthorized, a human sponsor owner must approve the wallet manually. Does not create, fund, or approve anything.",
+    inputSchema: {},
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    }
+  }, async () => {
+    try {
+      const access = await client.getAccess();
+      const data = {
+        ...access,
+        ...!access.authorized ? {
+          error: "approval_required",
+          message: "Ask the sponsor owner to approve this wallet. Copy the approval URL for manual review; do not auto-open or submit approval.",
+          approval_url: `https://droplit.dev${access.approval_path}`
+        } : {}
+      };
+      return {
+        ...createSuccessResponse(data),
+        structuredContent: data,
+        isError: !access.authorized
+      };
+    } catch (error52) {
+      return errorResult(error52);
+    }
+  });
+  server.registerTool("droplit_push", {
+    description: "Submit one sponsored data transaction. Subject to sponsor approval and quotas. An unknown outcome requires checking transaction history before retrying.",
+    inputSchema: {
+      data: exports_external.array(exports_external.string()).min(1),
+      encoding: exports_external.enum(["hex", "utf8"])
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true
+    }
+  }, async ({ data, encoding }) => {
+    try {
+      if (disableBroadcasting)
+        throw new Error("Broadcasting disabled");
+      assertBroadcastAllowed("droplit_push");
+      return createSuccessResponse(await client.push(data, encoding));
+    } catch (error52) {
+      return errorResult(error52);
+    }
+  });
+  server.registerTool("droplit_fund", {
+    description: "Submit one raw transaction for sponsor funding and broadcast. Subject to sponsor approval and quotas. Unknown outcomes must be reconciled before retrying.",
+    inputSchema: {
+      rawtx: exports_external.string().min(2).regex(/^(?:[0-9a-fA-F]{2})+$/, "Expected raw transaction hex")
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true
+    }
+  }, async ({ rawtx }) => {
+    try {
+      if (disableBroadcasting)
+        throw new Error("Broadcasting disabled");
+      assertBroadcastAllowed("droplit_fund");
+      return createSuccessResponse(await client.fund(rawtx));
+    } catch (error52) {
+      return errorResult(error52);
+    }
+  });
+}
+
 // tools/wallet/getBalanceDroplit.ts
 function registerWalletGetBalanceDroplitTool(server, droplitClient) {
   server.tool("wallet_getBalance", "Gets the current balance of the wallet (Droplit mode)", {}, async () => {
@@ -284911,16 +285186,13 @@ function registerWalletGetBalanceDroplitTool(server, droplitClient) {
 }
 
 // tools/wallet/setupDroplit.ts
-function requireDroplit(integratedWallet) {
+async function requireDroplit(integratedWallet) {
   const client = integratedWallet.getDroplitClient();
   if (!client) {
     throw new Error("Droplit client is not configured. Set DROPLIT_API_URL and DROPLIT_FAUCET_NAME.");
   }
-  const { apiUrl, authKey } = client.getConfig();
-  if (!authKey) {
-    throw new Error("Droplit requests must be signed, but no auth key is configured.");
-  }
-  return { apiUrl, publicKeyHex: authKey.toPublicKey().toString(), client };
+  const { apiUrl } = client.getConfig();
+  return { apiUrl, publicKeyHex: await client.getIdentityKey(), client };
 }
 async function failIfNotOk(response, attempted) {
   if (response.ok)
@@ -284928,9 +285200,9 @@ async function failIfNotOk(response, attempted) {
   throw new Error(`${attempted} failed (${response.status}): ${await response.text()}`);
 }
 function registerSetupDroplitTools(server, integratedWallet) {
-  server.tool("wallet_registerDroplitKey", "Registers this wallet's public key with the Droplit API so it can sign authenticated faucet requests. Run once before creating or operating a faucet.", {}, async () => {
+  server.tool("wallet_registerDroplitKey", "Registers public authentication material. Registration does not grant sponsor access; a sponsor owner must approve the wallet separately.", {}, async () => {
     try {
-      const { apiUrl, publicKeyHex } = requireDroplit(integratedWallet);
+      const { apiUrl, publicKeyHex } = await requireDroplit(integratedWallet);
       const response = await fetch(`${apiUrl}/auth/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -284945,13 +285217,13 @@ function registerSetupDroplitTools(server, integratedWallet) {
       return createErrorResponse(error52);
     }
   });
-  server.tool("wallet_createDroplitFaucet", "Provisions a new Droplit faucet owned by this wallet. Register the wallet's public key first with wallet_registerDroplitKey.", {
+  server.tool("wallet_createDroplitFaucet", "Creates a faucet owned by this wallet which must be funded before use. This does not provide free credit or approval for another sponsor.", {
     faucetName: exports_external.string().min(1).describe("Identifier for the new faucet; must be unique"),
     fixedDropSats: exports_external.number().int().positive().optional().describe("Satoshis paid out per tap. Server default applies if unset."),
     maxConsolidationInputs: exports_external.number().int().positive().optional().describe("Cap on inputs the faucet consolidates in one transaction")
   }, async ({ faucetName, fixedDropSats, maxConsolidationInputs }) => {
     try {
-      const { client } = requireDroplit(integratedWallet);
+      const { client } = await requireDroplit(integratedWallet);
       const body = {
         name: faucetName,
         ...fixedDropSats !== undefined && {
@@ -284974,9 +285246,9 @@ function registerSetupDroplitTools(server, integratedWallet) {
       return createErrorResponse(error52);
     }
   });
-  server.tool("wallet_checkDroplitFaucetStatus", "Reads the status of the configured Droplit faucet, including balance and payout settings.", {}, async () => {
+  server.tool("wallet_checkDroplitFaucetStatus", "Reads public faucet balance and payout settings. This is not proof of caller authorization; use droplit_getAccess for that.", {}, async () => {
     try {
-      const { client } = requireDroplit(integratedWallet);
+      const { client } = await requireDroplit(integratedWallet);
       return createSuccessResponse({
         faucetStatus: await client.getFaucetStatus()
       });
@@ -294891,7 +295163,7 @@ var package_default2 = {
   name: "bsv-mcp",
   module: "dist/index.js",
   type: "module",
-  version: "0.3.0",
+  version: "0.3.1",
   license: "MIT",
   author: "satchmo",
   description: "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",
@@ -295324,8 +295596,15 @@ function registerBrc100Tools(server, ctx) {
     txJSON: exports_external.string().describe("JSON array of AtomicBEEF bytes"),
     outputsJSON: exports_external.string().describe("JSON array of outputs to internalize"),
     description: exports_external.string().describe("5-50 char description"),
-    labelsJSON: exports_external.string().optional().describe("JSON array of label strings")
-  }, async ({ txJSON, outputsJSON, description, labelsJSON }) => {
+    labelsJSON: exports_external.string().optional().describe("JSON array of label strings"),
+    seekPermission: exports_external.boolean().optional()
+  }, async ({
+    txJSON,
+    outputsJSON,
+    description,
+    labelsJSON,
+    seekPermission
+  }) => {
     if (!ctx)
       return noCtx;
     try {
@@ -295333,6 +295612,7 @@ function registerBrc100Tools(server, ctx) {
         tx: parseRequiredJSON("txJSON", txJSON),
         outputs: parseRequiredJSON("outputsJSON", outputsJSON),
         description,
+        seekPermission,
         labels: parseJSON("labelsJSON", labelsJSON)
       }));
     } catch (e2) {
@@ -295349,7 +295629,8 @@ function registerBrc100Tools(server, ctx) {
     includeOutputs: exports_external.boolean().default(false),
     includeOutputLockingScripts: exports_external.boolean().default(false),
     limit: exports_external.number().default(25),
-    offset: exports_external.number().default(0)
+    offset: exports_external.number().default(0),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ labelsJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -295371,7 +295652,8 @@ function registerBrc100Tools(server, ctx) {
     includeTags: exports_external.boolean().default(false),
     includeLabels: exports_external.boolean().default(false),
     limit: exports_external.number().default(25),
-    offset: exports_external.number().default(0)
+    offset: exports_external.number().default(0),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ tagsJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -295423,7 +295705,9 @@ function registerBrc100Tools(server, ctx) {
     protocolIDJSON: exports_external.string().describe("JSON array [securityLevel, protocolString]"),
     keyID: exports_external.string(),
     counterparty: exports_external.string().optional(),
-    privileged: exports_external.boolean().optional()
+    privileged: exports_external.boolean().optional(),
+    privilegedReason: exports_external.string().optional(),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ protocolIDJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -295441,7 +295725,9 @@ function registerBrc100Tools(server, ctx) {
     protocolIDJSON: exports_external.string().describe("JSON array [securityLevel, protocolString]"),
     keyID: exports_external.string(),
     counterparty: exports_external.string().optional(),
-    privileged: exports_external.boolean().optional()
+    privileged: exports_external.boolean().optional(),
+    privilegedReason: exports_external.string().optional(),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ protocolIDJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -295459,7 +295745,9 @@ function registerBrc100Tools(server, ctx) {
     protocolIDJSON: exports_external.string().describe("JSON array [securityLevel, protocolString]"),
     keyID: exports_external.string(),
     counterparty: exports_external.string().optional(),
-    privileged: exports_external.boolean().optional()
+    privileged: exports_external.boolean().optional(),
+    privilegedReason: exports_external.string().optional(),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ protocolIDJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -295478,7 +295766,9 @@ function registerBrc100Tools(server, ctx) {
     protocolIDJSON: exports_external.string().describe("JSON array [securityLevel, protocolString]"),
     keyID: exports_external.string(),
     counterparty: exports_external.string().optional(),
-    privileged: exports_external.boolean().optional()
+    privileged: exports_external.boolean().optional(),
+    privilegedReason: exports_external.string().optional(),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ protocolIDJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -295497,7 +295787,9 @@ function registerBrc100Tools(server, ctx) {
     protocolIDJSON: exports_external.string().describe("JSON array [securityLevel, protocolString]"),
     keyID: exports_external.string(),
     counterparty: exports_external.string().optional(),
-    privileged: exports_external.boolean().optional()
+    privileged: exports_external.boolean().optional(),
+    privilegedReason: exports_external.string().optional(),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ protocolIDJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -295518,7 +295810,9 @@ function registerBrc100Tools(server, ctx) {
     keyID: exports_external.string(),
     counterparty: exports_external.string().optional(),
     forSelf: exports_external.boolean().optional(),
-    privileged: exports_external.boolean().optional()
+    privileged: exports_external.boolean().optional(),
+    privilegedReason: exports_external.string().optional(),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ protocolIDJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -295645,7 +295939,8 @@ function registerBrc100Tools(server, ctx) {
   server.tool("wallet_discoverByIdentityKey", "Discovers certificates issued to a given identity key.", {
     identityKey: exports_external.string().describe("Identity public key hex"),
     limit: exports_external.number().default(25),
-    offset: exports_external.number().default(0)
+    offset: exports_external.number().default(0),
+    seekPermission: exports_external.boolean().optional()
   }, async (args) => {
     if (!ctx)
       return noCtx;
@@ -295658,7 +295953,8 @@ function registerBrc100Tools(server, ctx) {
   server.tool("wallet_discoverByAttributes", "Discovers certificates matching specific attributes.", {
     attributesJSON: exports_external.string().describe("JSON object of attribute key/value pairs to match"),
     limit: exports_external.number().default(25),
-    offset: exports_external.number().default(0)
+    offset: exports_external.number().default(0),
+    seekPermission: exports_external.boolean().optional()
   }, async ({ attributesJSON, ...rest }) => {
     if (!ctx)
       return noCtx;
@@ -297365,14 +297661,16 @@ function registerWalletTools(server, wallet5, config2) {
   registerRefreshUtxosTool(server, config2.ctx);
   registerWalletGetBalanceTool(server, config2.ctx);
   registerBrc100Tools(server, config2.ctx);
-  if (config2.enableA2bTools) {
+  if (config2.enableA2bTools && wallet5 && config2.identityPk) {
     registerA2bPublishMcpTool(server, wallet5, config2.identityPk, {
       disableBroadcasting: config2.disableBroadcasting
     });
   }
   registerCreateOrdinalsTool(server, config2.ctx);
-  registerGatherCollectionInfoTool(server, wallet5);
-  registerMintCollectionTool(server, wallet5);
+  if (wallet5) {
+    registerGatherCollectionInfoTool(server, wallet5);
+    registerMintCollectionTool(server, wallet5);
+  }
   registerGetOrdinalsTool(server, config2.ctx);
   registerListTokensTool(server, config2.ctx);
   registerGetBsv21BalancesTool(server, config2.ctx);
@@ -297412,7 +297710,7 @@ function registerAllTools(server, config2 = {}) {
   if (enableA2bTools) {
     registerA2bDiscoverTool(server);
   }
-  if (enableBapTools) {
+  if (enableBapTools && (!config2.ctx || config2.wallet)) {
     const bapConfig = {
       disableBroadcasting: config2.disableBroadcasting,
       identityPk: config2.identityPk,
@@ -297425,6 +297723,8 @@ function registerAllTools(server, config2 = {}) {
     registerBsocialTools(server, { wallet: config2.wallet });
   }
   if (enableWalletTools) {
+    if (config2.droplitClient)
+      registerDroplitTools(server, config2.droplitClient, config2.disableBroadcasting);
     if (config2.integratedWallet?.isDroplitMode) {
       const droplitClient = config2.integratedWallet.getDroplitClient();
       if (droplitClient) {
@@ -297434,7 +297734,7 @@ function registerAllTools(server, config2 = {}) {
         }
         console.error("Registered Droplit mode wallet tools");
       }
-    } else if (config2.wallet) {
+    } else if (config2.wallet || config2.ctx) {
       const walletToolOptions = {
         disableBroadcasting: config2.disableBroadcasting === true,
         enableA2bTools,
@@ -297444,69 +297744,13 @@ function registerAllTools(server, config2 = {}) {
       registerWalletTools(server, config2.wallet, walletToolOptions);
     }
   }
-  if (enableMneeTools) {
+  if (enableMneeTools && (!config2.ctx || config2.wallet)) {
     registerMneeTools(server);
   }
 }
 
 // tools/wallet/integratedWallet.ts
 init_mod2();
-
-// utils/droplit.ts
-init_mod2();
-
-class DroplitClient {
-  config;
-  authFetch;
-  constructor(config2) {
-    this.config = config2;
-    if (config2.authKey) {
-      this.authFetch = new AuthFetch(new ProtoWallet_default(config2.authKey));
-    }
-  }
-  getConfig() {
-    return this.config;
-  }
-  get base() {
-    return this.config.apiUrl.replace(/\/+$/, "");
-  }
-  async authed(path5, init) {
-    if (!this.authFetch) {
-      throw new Error(`${path5} requires authentication and no Droplit auth key is configured.`);
-    }
-    return this.authFetch.fetch(`${this.base}${path5}`, {
-      method: init.method,
-      headers: { "Content-Type": "application/json" },
-      ...init.body === undefined ? {} : { body: JSON.stringify(init.body) }
-    });
-  }
-  async parse(response, attempted) {
-    if (response.ok)
-      return await response.json();
-    const raw = await response.text();
-    let detail = raw.slice(0, 200);
-    try {
-      const parsed = JSON.parse(raw);
-      detail = parsed.message ?? parsed.error ?? detail;
-    } catch {}
-    throw new Error(`${attempted} failed (${response.status}): ${detail}`);
-  }
-  async getFaucetStatus() {
-    const response = await fetch(`${this.base}/faucet/${this.config.faucetName}/status`);
-    return this.parse(response, "Reading the faucet status");
-  }
-  async tap(recipientAddress) {
-    const response = await this.authed(`/faucet/${this.config.faucetName}/tap`, { method: "POST", body: { recipient_address: recipientAddress } });
-    return this.parse(response, "Tapping the faucet");
-  }
-  async push(data, encoding = "hex") {
-    const response = await this.authed(`/faucet/${this.config.faucetName}/push`, { method: "POST", body: { data, encoding } });
-    return this.parse(response, "Pushing data");
-  }
-  async authenticatedFetch(path5, init) {
-    return this.authed(path5, init);
-  }
-}
 
 // tools/wallet/wallet.ts
 init_mod2();
@@ -297706,7 +297950,7 @@ class IntegratedWallet {
   }
   async sendToAddress(address, satoshis) {
     if (this.droplitClient) {
-      const response = await this.droplitClient.tap(address);
+      const response = await this.droplitClient.tap(address, satoshis);
       return { txid: response.txid };
     }
     if (this.localWallet) {
@@ -297910,6 +298154,245 @@ class Wallet2 {
       throw new Error(`Failed to broadcast transaction ${txidFromTxObject}: ${error53 instanceof Error ? error53.message : String(error53)}`);
     }
   }
+}
+
+// utils/droplit.ts
+init_mod2();
+function readDroplitSponsorConfig(env = process.env) {
+  const apiUrl = env.DROPLIT_API_URL;
+  const faucetName = env.DROPLIT_FAUCET_NAME;
+  if (apiUrl === undefined && faucetName === undefined)
+    return;
+  if (!apiUrl?.trim() || !faucetName?.trim()) {
+    throw new Error("DROPLIT_API_URL and DROPLIT_FAUCET_NAME must both be explicitly configured");
+  }
+  return { apiUrl, faucetName };
+}
+
+class DroplitError2 extends Error {
+  code;
+  status;
+  details;
+  constructor(code, message, status, details = {}) {
+    super(message);
+    this.code = code;
+    this.status = status;
+    this.details = details;
+  }
+}
+function quotaDetails2(body) {
+  if (!body || typeof body !== "object")
+    return {};
+  const value2 = body;
+  return {
+    ...typeof value2.remaining === "number" || value2.remaining === null ? { remaining: value2.remaining } : {},
+    ...typeof value2.resets_at === "string" ? { resets_at: value2.resets_at } : {}
+  };
+}
+function httpFailure2(status, details = {}) {
+  const known = {
+    401: [
+      "authentication_required",
+      "Authenticate with the configured wallet before retrying."
+    ],
+    402: [
+      "approval_required",
+      "Payment is required. No automatic payment was made; review payment with the wallet owner."
+    ],
+    403: [
+      "approval_required",
+      "The sponsor has not authorized this action. Ask its owner to approve your wallet."
+    ],
+    429: [
+      "quota_exceeded",
+      "Sponsor quota exhausted. Wait until resets_at or ask the owner to adjust your quota."
+    ]
+  };
+  const [code, message] = known[status] ?? [
+    "http_error",
+    "Droplit rejected the request. Check sponsor access and transaction history before retrying."
+  ];
+  return new DroplitError2(code, message, status, details);
+}
+
+class DroplitClient2 {
+  config;
+  authFetch;
+  wallet;
+  constructor(config2) {
+    this.config = config2;
+    if (config2.wallet && config2.authKey)
+      throw new Error("Configure Droplit wallet or authKey, not both");
+    const url3 = new URL(config2.apiUrl);
+    const loopback = url3.hostname === "localhost" || url3.hostname === "127.0.0.1" || url3.hostname === "[::1]";
+    if (url3.username || url3.password || url3.search || url3.hash || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
+      throw new Error("Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment");
+    }
+    if (!config2.faucetName.trim())
+      throw new Error("Droplit faucet name is required");
+    this.wallet = config2.wallet ?? (config2.authKey ? new ProtoWallet_default(config2.authKey) : undefined);
+    if (this.wallet) {
+      const authenticationWallet = new Proxy(this.wallet, {
+        get(target, property) {
+          if (property === "createAction" || property === "signAction") {
+            return async () => {
+              throw httpFailure2(402);
+            };
+          }
+          const value2 = Reflect.get(target, property, target);
+          return typeof value2 === "function" ? value2.bind(target) : value2;
+        }
+      });
+      this.authFetch = new AuthFetch(authenticationWallet);
+    }
+  }
+  getConfig() {
+    return { apiUrl: this.config.apiUrl, faucetName: this.config.faucetName };
+  }
+  async getIdentityKey() {
+    if (!this.wallet)
+      throw new DroplitError2("authentication_required", "Configure a Droplit wallet identity.");
+    const { publicKey } = await this.wallet.getPublicKey({ identityKey: true });
+    return publicKey;
+  }
+  get faucetPath() {
+    return `/faucet/${encodeURIComponent(this.config.faucetName)}`;
+  }
+  get base() {
+    return this.config.apiUrl.replace(/\/+$/, "");
+  }
+  async authed(path5, init) {
+    if (!this.authFetch) {
+      throw new Error(`${path5} requires authentication and no Droplit auth key is configured.`);
+    }
+    try {
+      return await this.authFetch.fetch(`${this.base}${path5}`, {
+        method: init.method,
+        headers: { "Content-Type": "application/json" },
+        ...init.body === undefined ? {} : { body: JSON.stringify(init.body) },
+        paymentRetryAttempts: 0,
+        ...init.method === "GET" || init.method === "HEAD" ? {} : { retryCounter: 1 }
+      });
+    } catch (error53) {
+      if (error53 instanceof DroplitError2)
+        throw error53;
+      const details = error53?.details;
+      const status = details?.status;
+      if (typeof status === "number" && [401, 402, 403, 429].includes(status)) {
+        let body;
+        if (status === 429 && typeof details?.bodyPreview === "string") {
+          try {
+            body = JSON.parse(details.bodyPreview);
+          } catch {}
+        }
+        throw httpFailure2(status, status === 429 ? quotaDetails2(body) : {});
+      }
+      const write = init.method !== "GET" && init.method !== "HEAD";
+      throw new DroplitError2(write ? "unknown_outcome" : "request_failed", write ? "Request outcome is unknown. Reconcile transaction/history before retrying; no automatic retry was made." : "Authenticated request failed. Check the signer and sponsor connection.");
+    }
+  }
+  async parse(response, _attempted) {
+    if (response.ok) {
+      try {
+        return await response.json();
+      } catch {
+        throw new DroplitError2("unknown_outcome", "Response could not be read. Reconcile transaction/history before retrying.", response.status);
+      }
+    }
+    let body = {};
+    try {
+      body = await response.json();
+    } catch {}
+    throw httpFailure2(response.status, response.status === 429 ? quotaDetails2(body) : {});
+  }
+  async getAccess() {
+    const response = await this.authed(`${this.faucetPath}/access`, {
+      method: "GET"
+    });
+    const access = await this.parse(response, "Reading sponsor access");
+    const identity6 = await this.getIdentityKey();
+    if (!access || access.public_key !== identity6 || access.slug !== this.config.faucetName || typeof access.authorized !== "boolean" || typeof access.is_owner !== "boolean" || !Array.isArray(access.quotas) || !Array.isArray(access.unrestricted_kinds)) {
+      throw new DroplitError2("invalid_response", "Sponsor access response did not match the authenticated wallet.");
+    }
+    access.approval_path = `/droplit/${encodeURIComponent(this.config.faucetName)}?tab=api&request_key=${encodeURIComponent(identity6)}`;
+    return access;
+  }
+  async fund(rawtx) {
+    const response = await this.authed(`${this.faucetPath}/fund`, {
+      method: "POST",
+      body: { rawtx }
+    });
+    return this.parse(response, "Funding transaction");
+  }
+  async getFaucetStatus() {
+    const response = await fetch(`${this.base}${this.faucetPath}/status`);
+    return this.parse(response, "Reading the faucet status");
+  }
+  async tap(recipientAddress, satoshis) {
+    if (satoshis !== undefined && (!Number.isSafeInteger(satoshis) || satoshis <= 0))
+      throw new Error("satoshis must be a positive safe integer");
+    const response = await this.authed(`${this.faucetPath}/tap`, {
+      method: "POST",
+      body: {
+        recipient_address: recipientAddress,
+        ...satoshis === undefined ? {} : { satoshis }
+      }
+    });
+    return this.parse(response, "Tapping the faucet");
+  }
+  async push(data, encoding = "hex") {
+    const response = await this.authed(`${this.faucetPath}/push`, {
+      method: "POST",
+      body: { data, encoding }
+    });
+    return this.parse(response, "Pushing data");
+  }
+  async authenticatedFetch(path5, init) {
+    return this.authed(path5, init);
+  }
+}
+
+// utils/externalWalletConfig.ts
+function readExternalWalletConfig(env = process.env) {
+  const raw = env.BRC100_WALLET_URL;
+  if (raw === undefined) {
+    if (env.BRC100_WALLET_ORIGINATOR !== undefined) {
+      throw new Error("BRC100_WALLET_ORIGINATOR requires BRC100_WALLET_URL");
+    }
+    return;
+  }
+  for (const name of ["PRIVATE_KEY_WIF", "IDENTITY_KEY_WIF"]) {
+    if (env[name] !== undefined) {
+      throw new Error(`BRC100_WALLET_URL conflicts with ${name}; select one wallet identity`);
+    }
+  }
+  if (env.USE_DROPLIT_API === "true") {
+    throw new Error("BRC100_WALLET_URL conflicts with USE_DROPLIT_API");
+  }
+  let url3;
+  try {
+    url3 = new URL(raw);
+  } catch {
+    throw new Error("BRC100_WALLET_URL must be a valid signer RPC URL");
+  }
+  const loopback = url3.hostname === "localhost" || url3.hostname === "[::1]" || /^127\.(?:\d{1,3}\.){2}\d{1,3}$/.test(url3.hostname);
+  if (!raw || raw !== raw.trim() || /[\\\s@?]/.test(raw) || url3.username || url3.password || raw.includes("#") || url3.search || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
+    throw new Error("BRC100_WALLET_URL requires HTTPS or HTTP loopback, without credentials, queries or fragments");
+  }
+  const originator = env.BRC100_WALLET_ORIGINATOR ?? "bsv-mcp.local";
+  let origin;
+  try {
+    origin = new URL(originator.includes("://") ? originator : `http://${originator}`);
+  } catch {
+    throw new Error("BRC100_WALLET_ORIGINATOR must be a domain or HTTP(S) origin");
+  }
+  if (!originator || /[\s\\]/.test(originator) || originator.length >= 250 || !["http:", "https:"].includes(origin.protocol) || origin.username || origin.password || origin.pathname !== "/" || origin.search || /[#?@]/.test(originator) || !/^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*|\[::1\])$/i.test(origin.hostname) || origin.hostname.toLowerCase() === "admin.bsv-mcp.internal") {
+    throw new Error("BRC100_WALLET_ORIGINATOR must be a non-admin domain or HTTP(S) origin without credentials, path, query or fragment");
+  }
+  return { url: url3.toString().replace(/\/$/, ""), originator };
+}
+async function initializeKeysForWalletMode(external4, loadLocalKeys) {
+  return external4 ? undefined : loadLocalKeys();
 }
 
 // node_modules/jose/dist/webapi/lib/buffer_utils.js
@@ -301997,9 +302480,19 @@ async function buildLocalStorage(config2, baseOptions) {
 init_storage_pg();
 var import_wallet_toolbox2 = __toESM(require_src6(), 1);
 
+// node_modules/@1sat/wallet-remote/dist/index.js
+init_dist4();
+
+// node_modules/@1sat/wallet-remote/dist/createRemoteWallet.js
+init_dist4();
+var import_index_client2 = __toESM(require_index_client5(), 1);
+
+// node_modules/@1sat/wallet-remote/dist/index.js
+var import_index_client3 = __toESM(require_index_client5(), 1);
+
 // utils/walletInit.ts
 init_mod2();
-var import_index_client2 = __toESM(require_index_client5(), 1);
+var import_index_client4 = __toESM(require_index_client5(), 1);
 
 // utils/spendingApproval.ts
 var serverInstance2 = null;
@@ -302096,7 +302589,7 @@ async function initWallet(privateKeyWif, chain = "main") {
     activeRemote: process.env.REMOTE_STORAGE_URL ?? DEFAULT_REMOTE_STORAGE_URL,
     storageIdentityKey: "bsv-mcp"
   });
-  const wpm = new import_index_client2.WalletPermissionsManager(result2.wallet, ADMIN_ORIGINATOR, {
+  const wpm = new import_index_client4.WalletPermissionsManager(result2.wallet, ADMIN_ORIGINATOR, {
     seekProtocolPermissionsForSigning: false,
     seekProtocolPermissionsForEncrypting: false,
     seekProtocolPermissionsForHMAC: false,
@@ -302138,7 +302631,7 @@ async function initWallet(privateKeyWif, chain = "main") {
   }).catch((err) => {
     console.error("[wallet] message box sync failed:", err);
   });
-  activeResult = { ...result2, ctx, depositAddress };
+  activeResult = result2;
   return {
     wallet: wpm,
     services: result2.services,
@@ -302146,6 +302639,36 @@ async function initWallet(privateKeyWif, chain = "main") {
     depositAddress,
     destroy: result2.destroy
   };
+}
+async function initExternalWallet(config2, chain = "main") {
+  const httpClient = (input, init) => fetch(input, {
+    ...init,
+    redirect: "error",
+    signal: init?.signal ? AbortSignal.any([init.signal, AbortSignal.timeout(1e4)]) : AbortSignal.timeout(1e4)
+  });
+  const wallet7 = new HTTPWalletJSON(config2.originator, config2.url, httpClient);
+  let identityKey;
+  try {
+    const identity6 = await wallet7.getPublicKey({ identityKey: true });
+    if (!/^(02|03)[0-9a-f]{64}$/i.test(identity6.publicKey)) {
+      throw new Error("Signer returned an invalid compressed identity public key");
+    }
+    PublicKey.fromString(identity6.publicKey);
+    identityKey = identity6.publicKey;
+  } catch (error53) {
+    throw new Error("External BRC-100 signer readiness failed. Check BRC100_WALLET_URL and approve identity access in the signer. This must be SDK signer RPC, not 1sat serve wallet storage RPC. No local wallet was created.", { cause: error53 });
+  }
+  const services2 = new OneSatServices(chain, process.env.ONESAT_API_URL);
+  const dataDir = join2(homedir(), ".bsv-mcp");
+  const ctx = createContext(wallet7, {
+    services: services2,
+    chain,
+    dataDir,
+    log: (entry) => writeAuditLog(dataDir, entry)
+  });
+  const destroy = async () => {};
+  activeResult = { destroy };
+  return { wallet: wallet7, ctx, services: services2, identityKey, destroy };
 }
 async function destroyWallet() {
   if (activeResult) {
@@ -302283,7 +302806,7 @@ async function initializeKeys() {
 }
 var APP_RESOURCE_URI = "ui://bsv-mcp/app.html";
 var __appDirname = dirname2(fileURLToPath(import.meta.url));
-function registerMcpAppTools(server2, wallet6, ctx) {
+function registerMcpAppTools(server2, wallet7, ctx) {
   K3(server2, "bsv_dashboard", {
     title: "BSV Dashboard",
     description: "Interactive BSV dashboard with Explorer, Wallet, and Ordinals tabs. Use this for any BSV-related query that benefits from visual display.",
@@ -302433,7 +302956,7 @@ function registerMcpAppTools(server2, wallet6, ctx) {
       ui: { resourceUri: APP_RESOURCE_URI, visibility: ["app"] }
     }
   }, async () => {
-    if (!ctx && !wallet6) {
+    if (!ctx && !wallet7) {
       return {
         content: [
           {
@@ -302465,9 +302988,9 @@ function registerMcpAppTools(server2, wallet6, ctx) {
           const [txid = "", voutStr = "0"] = (o6.outpoint ?? "").split(".");
           return { txid, vout: Number(voutStr), satoshis: o6.satoshis };
         });
-      } else if (wallet6) {
-        address = wallet6.getAddress();
-        const { paymentUtxos } = await wallet6.getUtxos();
+      } else if (wallet7) {
+        address = wallet7.getAddress();
+        const { paymentUtxos } = await wallet7.getUtxos();
         for (const utxo of paymentUtxos) {
           totalSatoshis += utxo.satoshis || 0;
         }
@@ -302892,6 +303415,8 @@ Options:
 Environment Variables:
   TRANSPORT           Transport mode: 'stdio' or 'http' (default: http)
   PORT               HTTP server port (default: 3000)
+  BRC100_WALLET_URL  Existing SDK HTTPWalletJSON signer RPC URL
+  BRC100_WALLET_ORIGINATOR  Signer permission origin (default: bsv-mcp.local)
   PRIVATE_KEY_WIF    Payment private key in WIF format
   DISABLE_TOOLS      Disable all tools (default: false)
   DISABLE_WALLET_TOOLS   Disable wallet tools (default: false)
@@ -302915,7 +303440,7 @@ Tool Categories:
 
 Authentication:
   - Most tools work without authentication
-  - Wallet operations require PRIVATE_KEY_WIF or generated keys
+  - Wallet operations use BRC100_WALLET_URL, PRIVATE_KEY_WIF or generated keys
   - BAP/A2B tools require identity keys (generated via bap_generate tool)
 		`);
     process.exit(0);
@@ -302924,11 +303449,31 @@ Authentication:
     console.log(`${package_default.name} v${package_default.version}`);
     process.exit(0);
   }
-  const { payPk, identityPk, xprv, source: keySource } = await initializeKeys();
+  const externalWallet = readExternalWalletConfig();
+  const sponsorConfig = CONFIG.useDroplitApi ? undefined : readDroplitSponsorConfig();
+  const keys = await initializeKeysForWalletMode(externalWallet, initializeKeys);
+  const {
+    payPk,
+    identityPk,
+    xprv,
+    source: keySource
+  } = keys ?? {
+    payPk: undefined,
+    identityPk: undefined,
+    xprv: undefined,
+    source: "external"
+  };
   const hasPersistentPayKey = keySource === "env" || keySource === "file" || keySource === "encrypted";
   const hasPersistentIdentityKey = !!identityPk && (keySource === "file" || keySource === "encrypted");
   const hasXprv = !!xprv && (keySource === "file" || keySource === "env" || keySource === "encrypted");
   const effectiveConfig = { ...CONFIG };
+  if (externalWallet) {
+    effectiveConfig.loadBapTools = false;
+    effectiveConfig.loadBsocialTools = false;
+    effectiveConfig.loadMneeTools = false;
+    effectiveConfig.loadA2bTools = false;
+    logFunc2("External BRC-100 signer selected; local key loading and generation bypassed.");
+  }
   logFunc2(`
 --- BSV MCP Server Configuration ---`);
   logFunc2(`Server Version: ${package_default.version}`);
@@ -302939,8 +303484,8 @@ Environment Variables:`);
   if (CONFIG.transportMode === "http") {
     logFunc2(`  PORT:                 ${process.env.PORT || "Not Set (3000 default)"}`);
   }
-  logFunc2(`  PRIVATE_KEY_WIF:      ${process.env.PRIVATE_KEY_WIF ? "Set (using env key)" : "Not Set (using file/generating)"}`);
-  logFunc2(`  IDENTITY_KEY_WIF:     ${process.env.IDENTITY_KEY_WIF ? "Set (using env key)" : "Not Set (using file/generating)"}`);
+  logFunc2(`  PRIVATE_KEY_WIF:      ${externalWallet ? "Unused (external signer)" : process.env.PRIVATE_KEY_WIF ? "Set (using env key)" : "Not Set (using file/generating)"}`);
+  logFunc2(`  IDENTITY_KEY_WIF:     ${externalWallet ? "Unused (external signer)" : process.env.IDENTITY_KEY_WIF ? "Set (using env key)" : "Not Set (using file/generating)"}`);
   if (process.env.BSV_MCP_PASSPHRASE) {
     logFunc2("  BSV_MCP_PASSPHRASE:   \x1B[31mDEPRECATED - Remove this!\x1B[0m");
   }
@@ -302996,11 +303541,11 @@ Effective Component Status:`);
     const a2bStatus = effectiveConfig.loadA2bTools ? "\x1B[32mEnabled\x1B[0m" : "\x1B[31mDisabled\x1B[0m";
     const bapStatus = effectiveConfig.loadBapTools ? "\x1B[32mEnabled\x1B[0m" : "\x1B[31mDisabled\x1B[0m";
     let payKeyNote = "";
-    if (!hasPersistentPayKey) {
+    if (!externalWallet && !hasPersistentPayKey) {
       payKeyNote = " \x1B[33m(Using generated payPk)\x1B[0m";
     }
     let identityKeyNote = "";
-    if (!hasPersistentIdentityKey) {
+    if (!externalWallet && !hasPersistentIdentityKey) {
       identityKeyNote = " \x1B[33m(Using generated identityPk)\x1B[0m";
     }
     logFunc2(`    Wallet:       ${walletStatus}${payKeyNote}`);
@@ -303017,12 +303562,20 @@ Effective Component Status:`);
   }
   logFunc2(`------------------------------------
 `);
-  let wallet6;
+  let wallet7;
   let integratedWallet;
   let remoteCtx;
   let remoteServices;
   if (CONFIG.loadTools) {
-    if (CONFIG.useDroplitApi && CONFIG.droplitFaucetName) {
+    if (externalWallet) {
+      const chain = process.env.BSV_CHAIN ?? "main";
+      if (chain !== "main" && chain !== "test")
+        throw new Error("BSV_CHAIN must be main or test");
+      const result2 = await initExternalWallet(externalWallet, chain);
+      remoteCtx = result2.ctx;
+      remoteServices = result2.services;
+      logFunc2(`External BRC-100 signer ready. Identity: ${result2.identityKey}`);
+    } else if (CONFIG.useDroplitApi && CONFIG.droplitFaucetName) {
       if (CONFIG.loadWalletTools) {
         try {
           integratedWallet = new IntegratedWallet({
@@ -303037,7 +303590,7 @@ Effective Component Status:`);
           logFunc2(`\x1B[32mINFO: Droplit API mode initialized successfully (Faucet: ${CONFIG.droplitFaucetName}).\x1B[0m`);
           logFunc2(`\x1B[33mNOTE: Using Droplit API at ${CONFIG.droplitApiUrl}\x1B[0m`);
           logFunc2("\x1B[33mNOTE: Local keys are ignored in Droplit API mode\x1B[0m");
-          wallet6 = integratedWallet.getLocalWallet();
+          wallet7 = integratedWallet.getLocalWallet();
           effectiveConfig.loadMneeTools = false;
           effectiveConfig.loadBapTools = false;
           effectiveConfig.loadA2bTools = false;
@@ -303053,7 +303606,7 @@ Effective Component Status:`);
     } else if (payPk) {
       if (CONFIG.loadWalletTools) {
         try {
-          wallet6 = new Wallet2(payPk, identityPk);
+          wallet7 = new Wallet2(payPk, identityPk);
           integratedWallet = new IntegratedWallet({
             paymentKey: payPk,
             identityKey: identityPk
@@ -303067,7 +303620,7 @@ Effective Component Status:`);
           }
         } catch (e2) {
           logFunc2(`\x1B[31mERROR: Failed to initialize custom wallet: ${e2 instanceof Error ? e2.message : String(e2)}. Wallet-dependent tools will be unavailable.\x1B[0m`);
-          wallet6 = undefined;
+          wallet7 = undefined;
           integratedWallet = undefined;
           effectiveConfig.loadWalletTools = false;
           effectiveConfig.loadMneeTools = false;
@@ -303083,11 +303636,15 @@ Effective Component Status:`);
           logFunc2(`\x1B[33mWARN: Remote BRC-100 wallet initialization failed: ${e2 instanceof Error ? e2.message : String(e2)}. Falling back to local wallet only.\x1B[0m`);
         }
       }
-      if (effectiveConfig.loadMneeTools && !wallet6 && CONFIG.loadWalletTools) {
+      if (effectiveConfig.loadMneeTools && !wallet7 && CONFIG.loadWalletTools) {
         logFunc2("\x1B[33mWARN: MNEE tools require a wallet but wallet initialization failed. MNEE tools disabled.\x1B[0m");
         effectiveConfig.loadMneeTools = false;
       }
     }
+  }
+  const droplitClient = sponsorConfig && remoteCtx ? new DroplitClient2({ ...sponsorConfig, wallet: remoteCtx.wallet }) : undefined;
+  if (sponsorConfig && CONFIG.loadTools && !remoteCtx) {
+    throw new Error("Configured Droplit sponsor requires an initialized BRC-100 wallet context");
   }
   const toolsConfig = CONFIG.loadTools ? {
     enableBsvTools: effectiveConfig.loadBsvTools,
@@ -303101,11 +303658,12 @@ Effective Component Status:`);
     identityPk,
     payPk,
     xprv,
-    wallet: wallet6,
+    wallet: wallet7,
     integratedWallet,
     disableBroadcasting: effectiveConfig.disableBroadcasting,
     ctx: remoteCtx,
-    services: remoteServices
+    services: remoteServices,
+    droplitClient
   } : {
     enableBsvTools: false,
     enableOrdinalsTools: false,
@@ -303119,7 +303677,7 @@ Effective Component Status:`);
   };
   const serverFactoryOpts = {
     toolsConfig,
-    wallet: wallet6,
+    wallet: wallet7,
     ctx: remoteCtx,
     loadPrompts: effectiveConfig.loadPrompts,
     loadResources: effectiveConfig.loadResources

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,11 @@ import { getBsvPriceWithCache } from "./tools/bsv/getPrice.ts";
 import { registerAllTools, type ToolsConfig } from "./tools/index.ts";
 import { IntegratedWallet } from "./tools/wallet/integratedWallet.ts";
 import { Wallet } from "./tools/wallet/wallet.ts";
+import { DroplitClient, readDroplitSponsorConfig } from "./utils/droplit";
+import {
+	initializeKeysForWalletMode,
+	readExternalWalletConfig,
+} from "./utils/externalWalletConfig";
 import {
 	type BSVJWTPayload,
 	createMCPJWTValidator,
@@ -37,6 +42,7 @@ import { SecureKeyManager } from "./utils/keyManager.ts";
 import { setServerInstance } from "./utils/passphrasePrompt.ts";
 import {
 	destroyWallet,
+	initExternalWallet,
 	initWallet,
 	setSpendingApprovalServerInstance,
 } from "./utils/walletInit.ts";
@@ -1107,6 +1113,8 @@ Options:
 Environment Variables:
   TRANSPORT           Transport mode: 'stdio' or 'http' (default: http)
   PORT               HTTP server port (default: 3000)
+  BRC100_WALLET_URL  Existing SDK HTTPWalletJSON signer RPC URL
+  BRC100_WALLET_ORIGINATOR  Signer permission origin (default: bsv-mcp.local)
   PRIVATE_KEY_WIF    Payment private key in WIF format
   DISABLE_TOOLS      Disable all tools (default: false)
   DISABLE_WALLET_TOOLS   Disable wallet tools (default: false)
@@ -1130,7 +1138,7 @@ Tool Categories:
 
 Authentication:
   - Most tools work without authentication
-  - Wallet operations require PRIVATE_KEY_WIF or generated keys
+  - Wallet operations use BRC100_WALLET_URL, PRIVATE_KEY_WIF or generated keys
   - BAP/A2B tools require identity keys (generated via bap_generate tool)
 		`);
 		process.exit(0);
@@ -1142,7 +1150,25 @@ Authentication:
 	}
 
 	// --- Initialize Keys ---
-	const { payPk, identityPk, xprv, source: keySource } = await initializeKeys();
+	const externalWallet = readExternalWalletConfig();
+	const sponsorConfig = CONFIG.useDroplitApi
+		? undefined
+		: readDroplitSponsorConfig();
+	const keys = await initializeKeysForWalletMode(
+		externalWallet,
+		initializeKeys,
+	);
+	const {
+		payPk,
+		identityPk,
+		xprv,
+		source: keySource,
+	} = keys ?? {
+		payPk: undefined,
+		identityPk: undefined,
+		xprv: undefined,
+		source: "external",
+	};
 
 	// Define persistence based on source
 	const hasPersistentPayKey =
@@ -1154,6 +1180,15 @@ Authentication:
 		(keySource === "file" || keySource === "env" || keySource === "encrypted");
 
 	const effectiveConfig = { ...CONFIG };
+	if (externalWallet) {
+		effectiveConfig.loadBapTools = false;
+		effectiveConfig.loadBsocialTools = false;
+		effectiveConfig.loadMneeTools = false;
+		effectiveConfig.loadA2bTools = false;
+		logFunc(
+			"External BRC-100 signer selected; local key loading and generation bypassed.",
+		);
+	}
 
 	// --- Configuration Logging ---
 	logFunc("\n--- BSV MCP Server Configuration ---");
@@ -1169,10 +1204,10 @@ Authentication:
 		);
 	}
 	logFunc(
-		`  PRIVATE_KEY_WIF:      ${process.env.PRIVATE_KEY_WIF ? "Set (using env key)" : "Not Set (using file/generating)"}`,
+		`  PRIVATE_KEY_WIF:      ${externalWallet ? "Unused (external signer)" : process.env.PRIVATE_KEY_WIF ? "Set (using env key)" : "Not Set (using file/generating)"}`,
 	);
 	logFunc(
-		`  IDENTITY_KEY_WIF:     ${process.env.IDENTITY_KEY_WIF ? "Set (using env key)" : "Not Set (using file/generating)"}`,
+		`  IDENTITY_KEY_WIF:     ${externalWallet ? "Unused (external signer)" : process.env.IDENTITY_KEY_WIF ? "Set (using env key)" : "Not Set (using file/generating)"}`,
 	);
 	if (process.env.BSV_MCP_PASSPHRASE) {
 		logFunc("  BSV_MCP_PASSPHRASE:   \x1b[31mDEPRECATED - Remove this!\x1b[0m");
@@ -1269,11 +1304,11 @@ Authentication:
 			: "\x1b[31mDisabled\x1b[0m";
 
 		let payKeyNote = "";
-		if (!hasPersistentPayKey) {
+		if (!externalWallet && !hasPersistentPayKey) {
 			payKeyNote = " \x1b[33m(Using generated payPk)\x1b[0m";
 		}
 		let identityKeyNote = "";
-		if (!hasPersistentIdentityKey) {
+		if (!externalWallet && !hasPersistentIdentityKey) {
 			identityKeyNote = " \x1b[33m(Using generated identityPk)\x1b[0m";
 		}
 
@@ -1310,7 +1345,15 @@ Authentication:
 
 	if (CONFIG.loadTools) {
 		// Check if we should use Droplit API mode
-		if (CONFIG.useDroplitApi && CONFIG.droplitFaucetName) {
+		if (externalWallet) {
+			const chain = process.env.BSV_CHAIN ?? "main";
+			if (chain !== "main" && chain !== "test")
+				throw new Error("BSV_CHAIN must be main or test");
+			const result = await initExternalWallet(externalWallet, chain);
+			remoteCtx = result.ctx;
+			remoteServices = result.services;
+			logFunc(`External BRC-100 signer ready. Identity: ${result.identityKey}`);
+		} else if (CONFIG.useDroplitApi && CONFIG.droplitFaucetName) {
 			// Initialize IntegratedWallet in Droplit mode
 			if (CONFIG.loadWalletTools) {
 				try {
@@ -1405,6 +1448,16 @@ Authentication:
 		}
 	}
 
+	const droplitClient =
+		sponsorConfig && remoteCtx
+			? new DroplitClient({ ...sponsorConfig, wallet: remoteCtx.wallet })
+			: undefined;
+	if (sponsorConfig && CONFIG.loadTools && !remoteCtx) {
+		throw new Error(
+			"Configured Droplit sponsor requires an initialized BRC-100 wallet context",
+		);
+	}
+
 	// Build the shared tools config (used by server factory for each session)
 	const toolsConfig: ToolsConfig = CONFIG.loadTools
 		? {
@@ -1424,6 +1477,7 @@ Authentication:
 				disableBroadcasting: effectiveConfig.disableBroadcasting,
 				ctx: remoteCtx,
 				services: remoteServices,
+				droplitClient,
 			}
 		: {
 				enableBsvTools: false,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bsv-mcp",
 	"module": "dist/index.js",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"license": "MIT",
 	"author": "satchmo",
 	"description": "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -2,6 +2,7 @@ import type { OneSatContext } from "@1sat/actions";
 import type { OneSatServices } from "@1sat/wallet-remote";
 import type { PrivateKey } from "@bsv/sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { DroplitClient } from "../utils/droplit";
 import { registerA2bDiscoverTool } from "./a2b/discover";
 import { registerBapTools } from "./bap";
 import { registerBsocialTools } from "./bsocial";
@@ -9,6 +10,7 @@ import { registerBsvTools } from "./bsv";
 import { registerMneeTools } from "./mnee";
 import { registerOrdinalsTools } from "./ordinals";
 import { registerUtilsTools } from "./utils";
+import { registerDroplitTools } from "./wallet/droplit";
 import { registerWalletGetBalanceDroplitTool } from "./wallet/getBalanceDroplit";
 import type { IntegratedWallet } from "./wallet/integratedWallet";
 import { registerSetupDroplitTools } from "./wallet/setupDroplit";
@@ -45,6 +47,7 @@ export interface ToolsConfig {
 	disableBroadcasting?: boolean; // For wallet tools
 	ctx?: OneSatContext;
 	services?: OneSatServices;
+	droplitClient?: DroplitClient;
 }
 
 /**
@@ -99,7 +102,7 @@ export function registerAllTools(
 	}
 
 	// Register BAP tools
-	if (enableBapTools) {
+	if (enableBapTools && (!config.ctx || config.wallet)) {
 		const bapConfig: import("./bap").BapToolsConfig = {
 			disableBroadcasting: config.disableBroadcasting,
 			identityPk: config.identityPk,
@@ -116,6 +119,12 @@ export function registerAllTools(
 
 	// Register Wallet tools themselves
 	if (enableWalletTools) {
+		if (config.droplitClient)
+			registerDroplitTools(
+				server,
+				config.droplitClient,
+				config.disableBroadcasting,
+			);
 		if (config.integratedWallet?.isDroplitMode) {
 			// Register Droplit-mode wallet tools
 			const droplitClient = config.integratedWallet.getDroplitClient();
@@ -127,7 +136,7 @@ export function registerAllTools(
 				}
 				console.error("Registered Droplit mode wallet tools");
 			}
-		} else if (config.wallet) {
+		} else if (config.wallet || config.ctx) {
 			// Register normal wallet tools
 			const walletToolOptions = {
 				disableBroadcasting: config.disableBroadcasting === true,
@@ -140,7 +149,7 @@ export function registerAllTools(
 	}
 
 	// Register MNEE tools
-	if (enableMneeTools) {
+	if (enableMneeTools && (!config.ctx || config.wallet)) {
 		registerMneeTools(server);
 	}
 

--- a/tools/wallet/brc100.ts
+++ b/tools/wallet/brc100.ts
@@ -184,8 +184,15 @@ export function registerBrc100Tools(
 			outputsJSON: z.string().describe("JSON array of outputs to internalize"),
 			description: z.string().describe("5-50 char description"),
 			labelsJSON: z.string().optional().describe("JSON array of label strings"),
+			seekPermission: z.boolean().optional(),
 		},
-		async ({ txJSON, outputsJSON, description, labelsJSON }) => {
+		async ({
+			txJSON,
+			outputsJSON,
+			description,
+			labelsJSON,
+			seekPermission,
+		}) => {
 			if (!ctx) return noCtx;
 			try {
 				return result(
@@ -193,6 +200,7 @@ export function registerBrc100Tools(
 						tx: parseRequiredJSON("txJSON", txJSON),
 						outputs: parseRequiredJSON("outputsJSON", outputsJSON),
 						description,
+						seekPermission,
 						labels: parseJSON("labelsJSON", labelsJSON),
 					}),
 				);
@@ -221,6 +229,7 @@ export function registerBrc100Tools(
 			includeOutputLockingScripts: z.boolean().default(false),
 			limit: z.number().default(25),
 			offset: z.number().default(0),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ labelsJSON, ...rest }) => {
 			if (!ctx) return noCtx;
@@ -250,6 +259,7 @@ export function registerBrc100Tools(
 			includeLabels: z.boolean().default(false),
 			limit: z.number().default(25),
 			offset: z.number().default(0),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ tagsJSON, ...rest }) => {
 			if (!ctx) return noCtx;
@@ -331,6 +341,8 @@ export function registerBrc100Tools(
 			keyID: z.string(),
 			counterparty: z.string().optional(),
 			privileged: z.boolean().optional(),
+			privilegedReason: z.string().optional(),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ protocolIDJSON, ...rest }) => {
 			if (!ctx) return noCtx;
@@ -358,6 +370,8 @@ export function registerBrc100Tools(
 			keyID: z.string(),
 			counterparty: z.string().optional(),
 			privileged: z.boolean().optional(),
+			privilegedReason: z.string().optional(),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ protocolIDJSON, ...rest }) => {
 			if (!ctx) return noCtx;
@@ -385,6 +399,8 @@ export function registerBrc100Tools(
 			keyID: z.string(),
 			counterparty: z.string().optional(),
 			privileged: z.boolean().optional(),
+			privilegedReason: z.string().optional(),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ protocolIDJSON, ...rest }) => {
 			if (!ctx) return noCtx;
@@ -413,6 +429,8 @@ export function registerBrc100Tools(
 			keyID: z.string(),
 			counterparty: z.string().optional(),
 			privileged: z.boolean().optional(),
+			privilegedReason: z.string().optional(),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ protocolIDJSON, ...rest }) => {
 			if (!ctx) return noCtx;
@@ -444,6 +462,8 @@ export function registerBrc100Tools(
 			keyID: z.string(),
 			counterparty: z.string().optional(),
 			privileged: z.boolean().optional(),
+			privilegedReason: z.string().optional(),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ protocolIDJSON, ...rest }) => {
 			if (!ctx) return noCtx;
@@ -480,6 +500,8 @@ export function registerBrc100Tools(
 			counterparty: z.string().optional(),
 			forSelf: z.boolean().optional(),
 			privileged: z.boolean().optional(),
+			privilegedReason: z.string().optional(),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ protocolIDJSON, ...rest }) => {
 			if (!ctx) return noCtx;
@@ -677,6 +699,7 @@ export function registerBrc100Tools(
 			identityKey: z.string().describe("Identity public key hex"),
 			limit: z.number().default(25),
 			offset: z.number().default(0),
+			seekPermission: z.boolean().optional(),
 		},
 		async (args) => {
 			if (!ctx) return noCtx;
@@ -697,6 +720,7 @@ export function registerBrc100Tools(
 				.describe("JSON object of attribute key/value pairs to match"),
 			limit: z.number().default(25),
 			offset: z.number().default(0),
+			seekPermission: z.boolean().optional(),
 		},
 		async ({ attributesJSON, ...rest }) => {
 			if (!ctx) return noCtx;

--- a/tools/wallet/droplit.ts
+++ b/tools/wallet/droplit.ts
@@ -1,0 +1,124 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { assertBroadcastAllowed } from "../../utils/broadcastGuard";
+import { type DroplitClient, DroplitError } from "../../utils/droplit";
+import { createSuccessResponse } from "../utils/errorHandler";
+
+function errorResult(error: unknown) {
+	const failure =
+		error instanceof DroplitError
+			? error
+			: new DroplitError(
+					"request_failed",
+					"Droplit operation failed. Check configuration and broadcasting policy.",
+				);
+	const data = {
+		error: failure.code,
+		message: failure.message,
+		...(failure.status === undefined ? {} : { status: failure.status }),
+		...failure.details,
+	};
+	return {
+		...createSuccessResponse(data),
+		structuredContent: data,
+		isError: true,
+	};
+}
+
+export function registerDroplitTools(
+	server: McpServer,
+	client: DroplitClient,
+	disableBroadcasting = false,
+) {
+	server.registerTool(
+		"droplit_getAccess",
+		{
+			description:
+				"Read this connected wallet's sponsor authorization and quotas. If unauthorized, a human sponsor owner must approve the wallet manually. Does not create, fund, or approve anything.",
+			inputSchema: {},
+			annotations: {
+				readOnlyHint: true,
+				destructiveHint: false,
+				idempotentHint: true,
+				openWorldHint: true,
+			},
+		},
+		async () => {
+			try {
+				const access = await client.getAccess();
+				const data = {
+					...access,
+					...(!access.authorized
+						? {
+								error: "approval_required",
+								message:
+									"Ask the sponsor owner to approve this wallet. Copy the approval URL for manual review; do not auto-open or submit approval.",
+								approval_url: `https://droplit.dev${access.approval_path}`,
+							}
+						: {}),
+				};
+				return {
+					...createSuccessResponse(data),
+					structuredContent: data,
+					isError: !access.authorized,
+				};
+			} catch (error) {
+				return errorResult(error);
+			}
+		},
+	);
+	server.registerTool(
+		"droplit_push",
+		{
+			description:
+				"Submit one sponsored data transaction. Subject to sponsor approval and quotas. An unknown outcome requires checking transaction history before retrying.",
+			inputSchema: {
+				data: z.array(z.string()).min(1),
+				encoding: z.enum(["hex", "utf8"]),
+			},
+			annotations: {
+				readOnlyHint: false,
+				destructiveHint: true,
+				idempotentHint: false,
+				openWorldHint: true,
+			},
+		},
+		async ({ data, encoding }) => {
+			try {
+				if (disableBroadcasting) throw new Error("Broadcasting disabled");
+				assertBroadcastAllowed("droplit_push");
+				return createSuccessResponse(await client.push(data, encoding));
+			} catch (error) {
+				return errorResult(error);
+			}
+		},
+	);
+	server.registerTool(
+		"droplit_fund",
+		{
+			description:
+				"Submit one raw transaction for sponsor funding and broadcast. Subject to sponsor approval and quotas. Unknown outcomes must be reconciled before retrying.",
+			inputSchema: {
+				rawtx: z
+					.string()
+					.min(2)
+					.regex(/^(?:[0-9a-fA-F]{2})+$/, "Expected raw transaction hex"),
+			},
+			annotations: {
+				readOnlyHint: false,
+				destructiveHint: true,
+				idempotentHint: false,
+				openWorldHint: true,
+			},
+		},
+		async ({ rawtx }) => {
+			try {
+				if (disableBroadcasting) throw new Error("Broadcasting disabled");
+				assertBroadcastAllowed("droplit_fund");
+				return createSuccessResponse(await client.fund(rawtx));
+			} catch (error) {
+				return errorResult(error);
+			}
+		},
+	);
+}

--- a/tools/wallet/integratedWallet.ts
+++ b/tools/wallet/integratedWallet.ts
@@ -66,9 +66,7 @@ export class IntegratedWallet {
 		satoshis: number,
 	): Promise<{ txid: string }> {
 		if (this.droplitClient) {
-			// For Droplit API, we use the tap endpoint which sends the faucet's fixed amount
-			// Note: Droplit API doesn't support custom amounts, it uses fixed_drop_sats
-			const response = await this.droplitClient.tap(address);
+			const response = await this.droplitClient.tap(address, satoshis);
 			return { txid: response.txid };
 		}
 		if (this.localWallet) {

--- a/tools/wallet/setupDroplit.ts
+++ b/tools/wallet/setupDroplit.ts
@@ -23,11 +23,11 @@ type DroplitClient = NonNullable<
  * signing key, so resolve both up front rather than failing part-way through a
  * request with a different message depending on which tool was called.
  */
-function requireDroplit(integratedWallet: IntegratedWallet): {
+async function requireDroplit(integratedWallet: IntegratedWallet): Promise<{
 	apiUrl: string;
 	publicKeyHex: string;
 	client: DroplitClient;
-} {
+}> {
 	const client = integratedWallet.getDroplitClient();
 	if (!client) {
 		throw new Error(
@@ -35,14 +35,8 @@ function requireDroplit(integratedWallet: IntegratedWallet): {
 		);
 	}
 
-	const { apiUrl, authKey } = client.getConfig();
-	if (!authKey) {
-		throw new Error(
-			"Droplit requests must be signed, but no auth key is configured.",
-		);
-	}
-
-	return { apiUrl, publicKeyHex: authKey.toPublicKey().toString(), client };
+	const { apiUrl } = client.getConfig();
+	return { apiUrl, publicKeyHex: await client.getIdentityKey(), client };
 }
 
 async function failIfNotOk(
@@ -61,11 +55,11 @@ export function registerSetupDroplitTools(
 ) {
 	server.tool(
 		"wallet_registerDroplitKey",
-		"Registers this wallet's public key with the Droplit API so it can sign authenticated faucet requests. Run once before creating or operating a faucet.",
+		"Registers public authentication material. Registration does not grant sponsor access; a sponsor owner must approve the wallet separately.",
 		{},
 		async () => {
 			try {
-				const { apiUrl, publicKeyHex } = requireDroplit(integratedWallet);
+				const { apiUrl, publicKeyHex } = await requireDroplit(integratedWallet);
 
 				const response = await fetch(`${apiUrl}/auth/register`, {
 					method: "POST",
@@ -86,7 +80,7 @@ export function registerSetupDroplitTools(
 
 	server.tool(
 		"wallet_createDroplitFaucet",
-		"Provisions a new Droplit faucet owned by this wallet. Register the wallet's public key first with wallet_registerDroplitKey.",
+		"Creates a faucet owned by this wallet which must be funded before use. This does not provide free credit or approval for another sponsor.",
 		{
 			faucetName: z
 				.string()
@@ -109,7 +103,7 @@ export function registerSetupDroplitTools(
 		},
 		async ({ faucetName, fixedDropSats, maxConsolidationInputs }) => {
 			try {
-				const { client } = requireDroplit(integratedWallet);
+				const { client } = await requireDroplit(integratedWallet);
 
 				// Ownership comes from the BRC-103/104 identity established by the
 				// handshake, not from the body, so the key is never sent here.
@@ -141,11 +135,11 @@ export function registerSetupDroplitTools(
 
 	server.tool(
 		"wallet_checkDroplitFaucetStatus",
-		"Reads the status of the configured Droplit faucet, including balance and payout settings.",
+		"Reads public faucet balance and payout settings. This is not proof of caller authorization; use droplit_getAccess for that.",
 		{},
 		async () => {
 			try {
-				const { client } = requireDroplit(integratedWallet);
+				const { client } = await requireDroplit(integratedWallet);
 				return createSuccessResponse({
 					faucetStatus: await client.getFaucetStatus(),
 				});

--- a/tools/wallet/tools.ts
+++ b/tools/wallet/tools.ts
@@ -31,7 +31,7 @@ import type { Wallet } from "./wallet";
 
 export function registerWalletTools(
 	server: McpServer,
-	wallet: Wallet,
+	wallet: Wallet | undefined,
 	config: {
 		disableBroadcasting: boolean;
 		enableA2bTools: boolean;
@@ -60,7 +60,7 @@ export function registerWalletTools(
 	registerBrc100Tools(server, config.ctx);
 
 	// A2B tools have to be explicitly enabled
-	if (config.enableA2bTools) {
+	if (config.enableA2bTools && wallet && config.identityPk) {
 		// Register the wallet_a2bPublishMcp tool
 		registerA2bPublishMcpTool(server, wallet, config.identityPk, {
 			disableBroadcasting: config.disableBroadcasting,
@@ -71,8 +71,10 @@ export function registerWalletTools(
 	registerCreateOrdinalsTool(server, config.ctx);
 
 	// Register collection tools
-	registerGatherCollectionInfoTool(server, wallet);
-	registerMintCollectionTool(server, wallet);
+	if (wallet) {
+		registerGatherCollectionInfoTool(server, wallet);
+		registerMintCollectionTool(server, wallet);
+	}
 
 	// Register read-only wallet tools
 	registerGetOrdinalsTool(server, config.ctx);

--- a/utils/droplit.test.ts
+++ b/utils/droplit.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import { createContext } from "@1sat/actions";
+import { AuthFetch, PrivateKey, type WalletInterface } from "@bsv/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAllTools } from "../tools";
+import { IntegratedWallet } from "../tools/wallet/integratedWallet";
+import {
+	DroplitClient,
+	DroplitError,
+	readDroplitSponsorConfig,
+} from "./droplit";
+
+const publicKey =
+	"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const config = {
+	apiUrl: "https://api.droplit.dev/droplit",
+	faucetName: "sponsor",
+};
+const access = {
+	slug: "sponsor",
+	public_key: publicKey,
+	authorized: false,
+	is_owner: false,
+	quotas: [],
+	unrestricted_kinds: [],
+	approval_path: "https://evil.example/approve",
+};
+function wallet() {
+	return {
+		getPublicKey: mock(async () => ({ publicKey })),
+	} as unknown as WalletInterface;
+}
+afterEach(() => mock.restore());
+
+test("sponsor configuration requires an explicit pair", () => {
+	expect(readDroplitSponsorConfig({})).toBeUndefined();
+	expect(() =>
+		readDroplitSponsorConfig({ DROPLIT_API_URL: config.apiUrl }),
+	).toThrow("both");
+	expect(() =>
+		readDroplitSponsorConfig({ DROPLIT_FAUCET_NAME: config.faucetName }),
+	).toThrow("both");
+	expect(
+		readDroplitSponsorConfig({
+			DROPLIT_API_URL: config.apiUrl,
+			DROPLIT_FAUCET_NAME: config.faucetName,
+		}),
+	).toEqual(config);
+});
+
+test("AuthFetch uses the actual connected wallet and identity, without exposing config secrets", async () => {
+	const signer = wallet();
+	const seen: unknown[] = [];
+	const fetch = spyOn(AuthFetch.prototype, "fetch").mockImplementation(
+		async function (this: AuthFetch) {
+			seen.push((this as unknown as { wallet: WalletInterface }).wallet);
+			return Response.json(access);
+		},
+	);
+	const client = new DroplitClient({ ...config, wallet: signer });
+	expect(await client.getIdentityKey()).toBe(publicKey);
+	await client.getAccess();
+	await client.getAccess();
+	expect(seen).toHaveLength(2);
+	expect(seen[0]).toBe(seen[1]);
+	expect(
+		await (seen[0] as WalletInterface).getPublicKey({ identityKey: true }),
+	).toEqual({ publicKey });
+	expect(signer.getPublicKey).toHaveBeenCalledWith({ identityKey: true });
+	expect(client.getConfig()).toEqual(config);
+	expect(fetch).toHaveBeenCalledTimes(2);
+	expect(
+		() =>
+			new DroplitClient({
+				...config,
+				wallet: signer,
+				authKey: PrivateKey.fromRandom(),
+			}),
+	).toThrow("not both");
+	const legacy = new DroplitClient({
+		...config,
+		authKey: PrivateKey.fromHex("01"),
+	});
+	expect(await legacy.getIdentityKey()).toBe(publicKey);
+	expect(legacy.getConfig()).not.toHaveProperty("authKey");
+});
+
+async function tools() {
+	const signer = wallet();
+	const server = new McpServer({ name: "droplit-test", version: "1" });
+	registerAllTools(server, {
+		ctx: createContext(signer),
+		droplitClient: new DroplitClient({ ...config, wallet: signer }),
+		enableBsvTools: false,
+		enableOrdinalsTools: false,
+		enableUtilsTools: false,
+		enableBapTools: false,
+		enableBsocialTools: false,
+		enableMneeTools: false,
+	});
+	const client = new Client({ name: "test", version: "1" });
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	await Promise.all([
+		server.connect(serverTransport),
+		client.connect(clientTransport),
+	]);
+	return {
+		client,
+		close: async () => {
+			await client.close();
+			await server.close();
+		},
+	};
+}
+
+test("denied access returns a trusted manual link with no mutation and keeps normal wallet tools", async () => {
+	const fetch = spyOn(AuthFetch.prototype, "fetch").mockResolvedValue(
+		Response.json(access),
+	);
+	const { client, close } = await tools();
+	try {
+		const list = await client.listTools();
+		expect(list.tools.some((tool) => tool.name.startsWith("wallet_"))).toBe(
+			true,
+		);
+		const read = list.tools.find((tool) => tool.name === "droplit_getAccess");
+		expect(read?.annotations?.readOnlyHint).toBe(true);
+		expect(
+			list.tools.find((tool) => tool.name === "droplit_push")?.annotations
+				?.idempotentHint,
+		).toBe(false);
+		const result = await client.callTool({
+			name: "droplit_getAccess",
+			arguments: {},
+		});
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toMatchObject({
+			error: "approval_required",
+			authorized: false,
+			approval_url: `https://droplit.dev/droplit/sponsor?tab=api&request_key=${publicKey}`,
+		});
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch.mock.calls[0][0]).toBe(
+			`${config.apiUrl}/faucet/sponsor/access`,
+		);
+		expect(fetch.mock.calls[0][1]?.method).toBe("GET");
+	} finally {
+		await close();
+	}
+});
+
+for (const [name, args, body] of [
+	[
+		"droplit_push",
+		{ data: ["hello"], encoding: "utf8" },
+		{ data: ["hello"], encoding: "utf8" },
+	],
+	["droplit_fund", { rawtx: "01000000" }, { rawtx: "01000000" }],
+] as const) {
+	test(`${name} sends canonical body once without auto-payment`, async () => {
+		const fetch = spyOn(AuthFetch.prototype, "fetch").mockResolvedValue(
+			Response.json({ txid: "test-txid" }),
+		);
+		const { client, close } = await tools();
+		try {
+			const result = await client.callTool({ name, arguments: args });
+			expect(result.isError).toBe(false);
+			expect(fetch).toHaveBeenCalledTimes(1);
+			expect(fetch.mock.calls[0][1]).toMatchObject({
+				method: "POST",
+				body: JSON.stringify(body),
+				paymentRetryAttempts: 0,
+				retryCounter: 1,
+			});
+		} finally {
+			await close();
+		}
+	});
+}
+
+for (const [status, code] of [
+	[401, "authentication_required"],
+	[402, "approval_required"],
+	[403, "approval_required"],
+	[429, "quota_exceeded"],
+] as const) {
+	test(`HTTP ${status} returns a structured actionable error without replay`, async () => {
+		const fetch = spyOn(AuthFetch.prototype, "fetch").mockResolvedValue(
+			Response.json(
+				{
+					error: "secret request dump",
+					remaining: 0,
+					resets_at: "2026-09-06T00:00:00Z",
+				},
+				{ status },
+			),
+		);
+		const { client, close } = await tools();
+		try {
+			const result = await client.callTool({
+				name: "droplit_push",
+				arguments: { data: ["hello"], encoding: "utf8" },
+			});
+			expect(result.isError).toBe(true);
+			expect(result.structuredContent).toMatchObject({ status, error: code });
+			if (status === 429)
+				expect(result.structuredContent).toMatchObject({
+					remaining: 0,
+					resets_at: "2026-09-06T00:00:00Z",
+				});
+			expect(JSON.stringify(result)).not.toContain("secret request dump");
+			expect(fetch).toHaveBeenCalledTimes(1);
+		} finally {
+			await close();
+		}
+	});
+}
+
+test("ambiguous writes submit once and require reconciliation", async () => {
+	const fetch = spyOn(AuthFetch.prototype, "fetch").mockRejectedValue(
+		new Error("transport failure containing private request"),
+	);
+	const { client, close } = await tools();
+	try {
+		const result = await client.callTool({
+			name: "droplit_fund",
+			arguments: { rawtx: "01000000" },
+		});
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toMatchObject({
+			error: "unknown_outcome",
+		});
+		expect(JSON.stringify(result)).toContain("Reconcile");
+		expect(JSON.stringify(result)).not.toContain("private request");
+		expect(fetch).toHaveBeenCalledTimes(1);
+	} finally {
+		await close();
+	}
+});
+
+test("legacy arbitrary tap amount reaches server satoshis field", async () => {
+	const fetch = spyOn(AuthFetch.prototype, "fetch").mockResolvedValue(
+		Response.json({ txid: "test" }),
+	);
+	const integrated = new IntegratedWallet({
+		useDroplitApi: true,
+		droplitConfig: { ...config },
+		paymentKey: PrivateKey.fromRandom(),
+	});
+	await integrated.sendToAddress("test-address", 1234);
+	expect(fetch).toHaveBeenCalledTimes(1);
+	expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).toEqual({
+		recipient_address: "test-address",
+		satoshis: 1234,
+	});
+});
+
+test("SDK status errors are sanitized and remain typed", async () => {
+	spyOn(AuthFetch.prototype, "fetch").mockRejectedValue(
+		Object.assign(new Error("private details"), {
+			details: { status: 403, bodyPreview: "private" },
+		}),
+	);
+	const client = new DroplitClient({ ...config, wallet: wallet() });
+	try {
+		await client.push(["00"]);
+		throw new Error("expected rejection");
+	} catch (error) {
+		expect(error).toBeInstanceOf(DroplitError);
+		expect(error).toMatchObject({ status: 403, code: "approval_required" });
+		expect(String(error)).not.toContain("private");
+	}
+});
+
+test("real SDK 402 payment processor cannot spend through the authentication facade", async () => {
+	const signer = {
+		getPublicKey: mock(async () => ({ publicKey })),
+		createHmac: mock(async () => ({ hmac: Array(32).fill(7) })),
+		createAction: mock(async () => ({ tx: [1] })),
+		signAction: mock(async () => ({})),
+	} as unknown as WalletInterface;
+	const client = new DroplitClient({ ...config, wallet: signer });
+	// Invoke the installed SDK payment processor unchanged, as its own payment
+	// tests do. A fetch mock alone would miss SDK auto-payment behavior.
+	const sdk = (client as unknown as { authFetch: AuthFetch }).authFetch;
+	const processPayment = Reflect.get(sdk, "handlePaymentAndRetry") as (
+		url: string,
+		init: object,
+		response: Response,
+	) => Promise<Response>;
+	const response = new Response(null, {
+		status: 402,
+		headers: {
+			"x-bsv-payment-version": "1.0",
+			"x-bsv-payment-satoshis-required": "5",
+			"x-bsv-auth-identity-key": publicKey,
+			"x-bsv-payment-derivation-prefix": "test-prefix",
+		},
+	});
+	await expect(
+		processPayment.call(
+			sdk,
+			config.apiUrl,
+			{ method: "POST", paymentRetryAttempts: 0 },
+			response,
+		),
+	).rejects.toMatchObject({ code: "approval_required", status: 402 });
+	expect(signer.createAction).not.toHaveBeenCalled();
+	expect(signer.signAction).not.toHaveBeenCalled();
+	expect(signer.getPublicKey).toHaveBeenCalled();
+});

--- a/utils/droplit.ts
+++ b/utils/droplit.ts
@@ -1,4 +1,9 @@
-import { AuthFetch, type PrivateKey, ProtoWallet } from "@bsv/sdk";
+import {
+	AuthFetch,
+	type PrivateKey,
+	ProtoWallet,
+	type WalletInterface,
+} from "@bsv/sdk";
 
 /**
  * Client for the Droplit faucet API (droplit-server, api.droplit.dev).
@@ -19,6 +24,85 @@ export interface DroplitConfig {
 	faucetName: string;
 	/** Identity for the BRC-103/104 handshake. Unauthenticated without it. */
 	authKey?: PrivateKey;
+	/** Connected signer; mutually exclusive with authKey. */
+	wallet?: WalletInterface;
+}
+
+export interface FaucetAccess {
+	slug: string;
+	public_key: string;
+	authorized: boolean;
+	is_owner: boolean;
+	quotas: Array<Record<string, unknown>>;
+	unrestricted_kinds: string[];
+	approval_path: string;
+}
+
+export function readDroplitSponsorConfig(
+	env: Record<string, string | undefined> = process.env,
+): Pick<DroplitConfig, "apiUrl" | "faucetName"> | undefined {
+	const apiUrl = env.DROPLIT_API_URL;
+	const faucetName = env.DROPLIT_FAUCET_NAME;
+	if (apiUrl === undefined && faucetName === undefined) return undefined;
+	if (!apiUrl?.trim() || !faucetName?.trim()) {
+		throw new Error(
+			"DROPLIT_API_URL and DROPLIT_FAUCET_NAME must both be explicitly configured",
+		);
+	}
+	return { apiUrl, faucetName };
+}
+
+export class DroplitError extends Error {
+	constructor(
+		readonly code: string,
+		message: string,
+		readonly status?: number,
+		readonly details: Record<string, unknown> = {},
+	) {
+		super(message);
+	}
+}
+
+function quotaDetails(body: unknown): Record<string, unknown> {
+	if (!body || typeof body !== "object") return {};
+	const value = body as Record<string, unknown>;
+	return {
+		...(typeof value.remaining === "number" || value.remaining === null
+			? { remaining: value.remaining }
+			: {}),
+		...(typeof value.resets_at === "string"
+			? { resets_at: value.resets_at }
+			: {}),
+	};
+}
+
+function httpFailure(
+	status: number,
+	details: Record<string, unknown> = {},
+): DroplitError {
+	const known: Record<number, [string, string]> = {
+		401: [
+			"authentication_required",
+			"Authenticate with the configured wallet before retrying.",
+		],
+		402: [
+			"approval_required",
+			"Payment is required. No automatic payment was made; review payment with the wallet owner.",
+		],
+		403: [
+			"approval_required",
+			"The sponsor has not authorized this action. Ask its owner to approve your wallet.",
+		],
+		429: [
+			"quota_exceeded",
+			"Sponsor quota exhausted. Wait until resets_at or ask the owner to adjust your quota.",
+		],
+	};
+	const [code, message] = known[status] ?? [
+		"http_error",
+		"Droplit rejected the request. Check sponsor access and transaction history before retrying.",
+	];
+	return new DroplitError(code, message, status, details);
 }
 
 export interface FaucetStatus {
@@ -46,15 +130,66 @@ export class DroplitClient {
 	 * fresh instance per call would repeat the handshake every request.
 	 */
 	private readonly authFetch?: AuthFetch;
+	private readonly wallet?: WalletInterface | ProtoWallet;
 
 	constructor(private config: DroplitConfig) {
-		if (config.authKey) {
-			this.authFetch = new AuthFetch(new ProtoWallet(config.authKey) as never);
+		if (config.wallet && config.authKey)
+			throw new Error("Configure Droplit wallet or authKey, not both");
+		const url = new URL(config.apiUrl);
+		const loopback =
+			url.hostname === "localhost" ||
+			url.hostname === "127.0.0.1" ||
+			url.hostname === "[::1]";
+		if (
+			url.username ||
+			url.password ||
+			url.search ||
+			url.hash ||
+			!(url.protocol === "https:" || (url.protocol === "http:" && loopback))
+		) {
+			throw new Error(
+				"Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment",
+			);
+		}
+		if (!config.faucetName.trim())
+			throw new Error("Droplit faucet name is required");
+		this.wallet =
+			config.wallet ??
+			(config.authKey ? new ProtoWallet(config.authKey) : undefined);
+		if (this.wallet) {
+			const authenticationWallet = new Proxy(this.wallet as WalletInterface, {
+				get(target, property) {
+					// SDK BRC-105 can create a payment even with paymentRetryAttempts: 0.
+					// Authentication may sign challenges, but it must never spend funds.
+					if (property === "createAction" || property === "signAction") {
+						return async () => {
+							throw httpFailure(402);
+						};
+					}
+					const value = Reflect.get(target, property, target);
+					return typeof value === "function" ? value.bind(target) : value;
+				},
+			});
+			this.authFetch = new AuthFetch(authenticationWallet);
 		}
 	}
 
-	getConfig(): DroplitConfig {
-		return this.config;
+	getConfig(): Pick<DroplitConfig, "apiUrl" | "faucetName"> {
+		return { apiUrl: this.config.apiUrl, faucetName: this.config.faucetName };
+	}
+
+	async getIdentityKey(): Promise<string> {
+		if (!this.wallet)
+			throw new DroplitError(
+				"authentication_required",
+				"Configure a Droplit wallet identity.",
+			);
+		const { publicKey } = await this.wallet.getPublicKey({ identityKey: true });
+		return publicKey;
+	}
+
+	private get faucetPath(): string {
+		return `/faucet/${encodeURIComponent(this.config.faucetName)}`;
 	}
 
 	private get base(): string {
@@ -76,51 +211,136 @@ export class DroplitClient {
 			);
 		}
 
-		return this.authFetch.fetch(`${this.base}${path}`, {
-			method: init.method,
-			headers: { "Content-Type": "application/json" },
-			...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
-		});
+		try {
+			return await this.authFetch.fetch(`${this.base}${path}`, {
+				method: init.method,
+				headers: { "Content-Type": "application/json" },
+				...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
+				paymentRetryAttempts: 0,
+				// One SDK submission: do not replay an ambiguous write on session failure.
+				...(init.method === "GET" || init.method === "HEAD"
+					? {}
+					: { retryCounter: 1 }),
+			});
+		} catch (error) {
+			if (error instanceof DroplitError) throw error;
+			// The SDK may reject an HTTP error without auth headers rather than return
+			// a Response. Preserve its status, but never expose its request/body preview.
+			const details = (
+				error as {
+					details?: { status?: unknown; bodyPreview?: unknown };
+				} | null
+			)?.details;
+			const status = details?.status;
+			if (typeof status === "number" && [401, 402, 403, 429].includes(status)) {
+				let body: unknown;
+				if (status === 429 && typeof details?.bodyPreview === "string") {
+					try {
+						body = JSON.parse(details.bodyPreview);
+					} catch {
+						/* Truncated SDK previews are not a quota record. */
+					}
+				}
+				throw httpFailure(status, status === 429 ? quotaDetails(body) : {});
+			}
+			const write = init.method !== "GET" && init.method !== "HEAD";
+			throw new DroplitError(
+				write ? "unknown_outcome" : "request_failed",
+				write
+					? "Request outcome is unknown. Reconcile transaction/history before retrying; no automatic retry was made."
+					: "Authenticated request failed. Check the signer and sponsor connection.",
+			);
+		}
 	}
 
-	private async parse<T>(response: Response, attempted: string): Promise<T> {
-		if (response.ok) return (await response.json()) as T;
-
-		// Errors come back as JSON, but a proxy or a plain 404 can answer with
-		// HTML, and JSON.parse on that buries the real status under a syntax
-		// error. Fall back to the raw text and always surface the status.
-		const raw = await response.text();
-		let detail = raw.slice(0, 200);
-		try {
-			const parsed = JSON.parse(raw) as { message?: string; error?: string };
-			detail = parsed.message ?? parsed.error ?? detail;
-		} catch {
-			// Not JSON — keep the raw excerpt.
+	private async parse<T>(response: Response, _attempted: string): Promise<T> {
+		if (response.ok) {
+			try {
+				return (await response.json()) as T;
+			} catch {
+				throw new DroplitError(
+					"unknown_outcome",
+					"Response could not be read. Reconcile transaction/history before retrying.",
+					response.status,
+				);
+			}
 		}
-		throw new Error(`${attempted} failed (${response.status}): ${detail}`);
+		let body: Record<string, unknown> = {};
+		try {
+			body = await response.json();
+		} catch {
+			/* Status is sufficient; never echo raw request/proxy output. */
+		}
+		throw httpFailure(
+			response.status,
+			response.status === 429 ? quotaDetails(body) : {},
+		);
+	}
+
+	async getAccess(): Promise<FaucetAccess> {
+		const response = await this.authed(`${this.faucetPath}/access`, {
+			method: "GET",
+		});
+		const access = await this.parse<FaucetAccess>(
+			response,
+			"Reading sponsor access",
+		);
+		const identity = await this.getIdentityKey();
+		if (
+			!access ||
+			access.public_key !== identity ||
+			access.slug !== this.config.faucetName ||
+			typeof access.authorized !== "boolean" ||
+			typeof access.is_owner !== "boolean" ||
+			!Array.isArray(access.quotas) ||
+			!Array.isArray(access.unrestricted_kinds)
+		) {
+			throw new DroplitError(
+				"invalid_response",
+				"Sponsor access response did not match the authenticated wallet.",
+			);
+		}
+		// Build the convenience path from our configuration and signer identity,
+		// never from an arbitrary server-supplied redirect.
+		access.approval_path = `/droplit/${encodeURIComponent(this.config.faucetName)}?tab=api&request_key=${encodeURIComponent(identity)}`;
+		return access;
+	}
+
+	async fund(rawtx: string): Promise<{ txid: string; rawtx?: string }> {
+		const response = await this.authed(`${this.faucetPath}/fund`, {
+			method: "POST",
+			body: { rawtx },
+		});
+		return this.parse(response, "Funding transaction");
 	}
 
 	/** Public route: no handshake, so this works without an auth key. */
 	async getFaucetStatus(): Promise<FaucetStatus> {
-		const response = await fetch(
-			`${this.base}/faucet/${this.config.faucetName}/status`,
-		);
+		const response = await fetch(`${this.base}${this.faucetPath}/status`);
 		return this.parse<FaucetStatus>(response, "Reading the faucet status");
 	}
 
-	async tap(recipientAddress: string): Promise<TapResponse> {
-		const response = await this.authed(
-			`/faucet/${this.config.faucetName}/tap`,
-			{ method: "POST", body: { recipient_address: recipientAddress } },
-		);
+	async tap(recipientAddress: string, satoshis?: number): Promise<TapResponse> {
+		if (
+			satoshis !== undefined &&
+			(!Number.isSafeInteger(satoshis) || satoshis <= 0)
+		)
+			throw new Error("satoshis must be a positive safe integer");
+		const response = await this.authed(`${this.faucetPath}/tap`, {
+			method: "POST",
+			body: {
+				recipient_address: recipientAddress,
+				...(satoshis === undefined ? {} : { satoshis }),
+			},
+		});
 		return this.parse<TapResponse>(response, "Tapping the faucet");
 	}
 
 	async push(data: string[], encoding = "hex"): Promise<PushResponse> {
-		const response = await this.authed(
-			`/faucet/${this.config.faucetName}/push`,
-			{ method: "POST", body: { data, encoding } },
-		);
+		const response = await this.authed(`${this.faucetPath}/push`, {
+			method: "POST",
+			body: { data, encoding },
+		});
 		return this.parse<PushResponse>(response, "Pushing data");
 	}
 

--- a/utils/externalWallet.test.ts
+++ b/utils/externalWallet.test.ts
@@ -1,0 +1,459 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { createContext } from "@1sat/actions";
+import * as nodeWallet from "@1sat/wallet-node";
+import { PrivateKey, type WalletInterface } from "@bsv/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAllTools } from "../tools";
+import {
+	initializeKeysForWalletMode,
+	readExternalWalletConfig,
+} from "./externalWalletConfig";
+import { SecureKeyManager } from "./keyManager";
+import { destroyWallet, initExternalWallet } from "./walletInit";
+
+const identityKey =
+	"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const config = { url: "http://127.0.0.1:3321", originator: "bsv-mcp.local" };
+afterEach(() => mock.restore());
+
+describe("external wallet configuration", () => {
+	it("allows an explicit sponsor alongside the signer", () => {
+		expect(
+			readExternalWalletConfig({
+				BRC100_WALLET_URL: config.url,
+				DROPLIT_API_URL: "https://api.droplit.dev/droplit",
+				DROPLIT_FAUCET_NAME: "sponsor",
+			}),
+		).toEqual(config);
+	});
+	it("preserves local selection and bypasses key loading only in explicit external mode", async () => {
+		const loader = mock(async () => ({ source: "local" }));
+		expect(readExternalWalletConfig({})).toBeUndefined();
+		expect(await initializeKeysForWalletMode(undefined, loader)).toEqual({
+			source: "local",
+		});
+		expect(await initializeKeysForWalletMode(config, loader)).toBeUndefined();
+		expect(loader).toHaveBeenCalledTimes(1);
+		expect(readExternalWalletConfig({ BRC100_WALLET_URL: config.url })).toEqual(
+			config,
+		);
+	});
+	for (const url of [
+		"",
+		"garbage",
+		"http://signer.example",
+		"ftp://localhost",
+		"https://user:pass@signer.example",
+		"https://signer.example/#fragment",
+		"http://127.0.0.1/?q=1",
+	]) {
+		it(`rejects signer URL ${url}`, () => {
+			expect(() =>
+				readExternalWalletConfig({ BRC100_WALLET_URL: url }),
+			).toThrow();
+		});
+	}
+	for (const originator of [
+		"",
+		" ",
+		"admin.bsv-mcp.internal",
+		"https://ADMIN.bsv-mcp.internal",
+		"https://user@wallet.example",
+		"https://wallet.example/path",
+		"https://wallet.example/?x=1",
+		"https://wallet.example/#",
+		"file:///tmp/wallet",
+		"wallet example",
+	]) {
+		it(`rejects originator ${originator}`, () => {
+			expect(() =>
+				readExternalWalletConfig({
+					BRC100_WALLET_URL: config.url,
+					BRC100_WALLET_ORIGINATOR: originator,
+				}),
+			).toThrow();
+		});
+	}
+	for (const conflict of [
+		"PRIVATE_KEY_WIF",
+		"IDENTITY_KEY_WIF",
+		"USE_DROPLIT_API",
+	]) {
+		it(`rejects explicit ${conflict} conflict`, () => {
+			expect(() =>
+				readExternalWalletConfig({
+					BRC100_WALLET_URL: config.url,
+					[conflict]: "true",
+				}),
+			).toThrow("conflicts");
+		});
+	}
+	it("accepts HTTPS and loopback, with a non-admin origin", () => {
+		for (const url of [
+			"https://signer.example/rpc",
+			"http://localhost:3321",
+			"http://127.0.0.2:3321",
+			"http://[::1]:3321",
+		]) {
+			expect(
+				readExternalWalletConfig({
+					BRC100_WALLET_URL: url,
+					BRC100_WALLET_ORIGINATOR: "https://agent.example",
+				})?.originator,
+			).toBe("https://agent.example");
+		}
+		expect(() =>
+			readExternalWalletConfig({ BRC100_WALLET_ORIGINATOR: "agent.example" }),
+		).toThrow("requires");
+	});
+});
+
+async function connectTools(wallet: WalletInterface) {
+	const server = new McpServer({ name: "external-test", version: "1.0.0" });
+	registerAllTools(server, {
+		ctx: createContext(wallet),
+		enableBsvTools: false,
+		enableOrdinalsTools: false,
+		enableUtilsTools: false,
+	});
+	const client = new Client({ name: "wallet-test", version: "1.0.0" });
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	await Promise.all([
+		server.connect(serverTransport),
+		client.connect(clientTransport),
+	]);
+	return {
+		client,
+		close: async () => {
+			await client.close();
+			await server.close();
+		},
+	};
+}
+
+describe("context-only wallet tools", () => {
+	for (const [method, payload] of [
+		["encrypt", { plaintext: [1] }],
+		["decrypt", { ciphertext: [1] }],
+		["createHmac", { data: [1] }],
+		["verifyHmac", { data: [1], hmac: [2] }],
+		["createSignature", { data: [1] }],
+		["verifySignature", { data: [1], signature: [2], forSelf: false }],
+	] as const) {
+		it(`preserves explicit permission and reason for ${method}`, async () => {
+			const call = mock(async (_args: unknown) => ({}));
+			const wallet = { [method]: call } as unknown as WalletInterface;
+			const { client, close } = await connectTools(wallet);
+			try {
+				for (const seekPermission of [false, true]) {
+					const args = {
+						...payload,
+						keyID: "test",
+						counterparty: "self",
+						privileged: true,
+						privilegedReason: "Caller supplied reason",
+						seekPermission,
+					};
+					const result = await client.callTool({
+						name: `wallet_${method}`,
+						arguments: { ...args, protocolIDJSON: '[2,"test protocol"]' },
+					});
+					expect(result.isError).not.toBe(true);
+					expect(call).toHaveBeenLastCalledWith({
+						...args,
+						protocolID: [2, "test protocol"],
+					});
+				}
+				call.mockImplementation(async () => {
+					throw new Error("Signer declined permission");
+				});
+				const result = await client.callTool({
+					name: `wallet_${method}`,
+					arguments: {
+						...payload,
+						keyID: "test",
+						protocolIDJSON: '[2,"test protocol"]',
+						seekPermission: false,
+						privilegedReason: "Keep this reason",
+					},
+				});
+				expect(result.isError).toBe(true);
+				expect(JSON.stringify(result.content)).toContain(
+					"Signer declined permission",
+				);
+				expect(call.mock.calls.at(-1)?.[0]).toMatchObject({
+					seekPermission: false,
+					privilegedReason: "Keep this reason",
+				});
+			} finally {
+				await close();
+			}
+		});
+	}
+	for (const [method, args] of [
+		[
+			"internalizeAction",
+			{ txJSON: "[1]", outputsJSON: "[]", description: "Test import" },
+		],
+		["listActions", { labelsJSON: "[]" }],
+		["listOutputs", { basket: "default" }],
+		["discoverByIdentityKey", { identityKey }],
+		["discoverByAttributes", { attributesJSON: '{"name":"test"}' }],
+	] as const) {
+		it(`preserves permission choice for ${method}`, async () => {
+			const call = mock(async (_args: unknown) => ({}));
+			const { client, close } = await connectTools({
+				[method]: call,
+			} as unknown as WalletInterface);
+			try {
+				for (const seekPermission of [false, true]) {
+					const result = await client.callTool({
+						name: `wallet_${method}`,
+						arguments: { ...args, seekPermission },
+					});
+					expect(result.isError).not.toBe(true);
+					expect(call.mock.calls.at(-1)?.[0]).toMatchObject({ seekPermission });
+				}
+			} finally {
+				await close();
+			}
+		});
+	}
+	it("forwards wallet arguments and permission rejection through real MCP calls", async () => {
+		const getPublicKey = mock(async () => ({ publicKey: identityKey }));
+		const listOutputs = mock(async () => ({ totalOutputs: 0, outputs: [] }));
+		const createSignature = mock(async () => ({ signature: [1, 2, 3] }));
+		const wallet = {
+			getPublicKey,
+			listOutputs,
+			createSignature,
+		} as unknown as WalletInterface;
+		const { client, close } = await connectTools(wallet);
+		try {
+			const catalog = (await client.listTools()).tools.map((tool) => tool.name);
+			for (const name of [
+				"wallet_getPublicKey",
+				"wallet_listOutputs",
+				"wallet_createSignature",
+				"wallet_sendBsv",
+				"wallet_getBalance",
+				"wallet_createAction",
+			])
+				expect(catalog).toContain(name);
+			for (const name of [
+				"wallet_mintCollection",
+				"wallet_gatherCollectionInfo",
+				"wallet_a2bPublishMcp",
+				"bap_generate",
+				"bap_getId",
+				"mnee_sendMnee",
+			])
+				expect(catalog).not.toContain(name);
+			const publicKeyArgs = {
+				identityKey: true,
+				seekPermission: true,
+				privileged: true,
+				privilegedReason: "test permission",
+			};
+			await client.callTool({
+				name: "wallet_getPublicKey",
+				arguments: publicKeyArgs,
+			});
+			expect(getPublicKey).toHaveBeenLastCalledWith({
+				...publicKeyArgs,
+				protocolID: undefined,
+			});
+			const outputArgs = {
+				basket: "test",
+				seekPermission: false,
+				tagQueryMode: "all",
+				include: "locking scripts",
+				includeCustomInstructions: true,
+				includeTags: true,
+				includeLabels: false,
+				limit: 3,
+				offset: 2,
+			};
+			await client.callTool({
+				name: "wallet_listOutputs",
+				arguments: { ...outputArgs, tagsJSON: '["test-tag"]' },
+			});
+			expect(listOutputs).toHaveBeenLastCalledWith({
+				...outputArgs,
+				tags: ["test-tag"],
+			});
+			const signatureArgs = {
+				data: [4, 5],
+				keyID: "test",
+				counterparty: "self",
+				privileged: false,
+				seekPermission: false,
+				privilegedReason: "Caller supplied reason",
+			};
+			await client.callTool({
+				name: "wallet_createSignature",
+				arguments: { ...signatureArgs, protocolIDJSON: '[2,"test protocol"]' },
+			});
+			expect(createSignature).toHaveBeenLastCalledWith({
+				...signatureArgs,
+				protocolID: [2, "test protocol"],
+			});
+			getPublicKey.mockImplementation(async () => {
+				throw new Error("Permission denied by signer");
+			});
+			const denied = await client.callTool({
+				name: "wallet_getPublicKey",
+				arguments: { identityKey: true, seekPermission: false },
+			});
+			expect(denied.isError).toBe(true);
+			expect(JSON.stringify(denied.content)).toContain(
+				"Permission denied by signer",
+			);
+			expect(getPublicKey).toHaveBeenLastCalledWith({
+				identityKey: true,
+				seekPermission: false,
+				protocolID: undefined,
+			});
+		} finally {
+			await close();
+		}
+	});
+});
+
+describe("external signer initialization", () => {
+	it("rejects signer redirects without following them", async () => {
+		let requests = 0;
+		const signer = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch() {
+				requests++;
+				return new Response(null, {
+					status: 302,
+					headers: { Location: "/different-wallet" },
+				});
+			},
+		});
+		try {
+			await expect(
+				initExternalWallet({
+					...config,
+					url: `http://127.0.0.1:${signer.port}`,
+				}),
+			).rejects.toThrow("External BRC-100 signer readiness failed");
+			expect(requests).toBe(1);
+		} finally {
+			await signer.stop(true);
+		}
+	});
+	it("aborts an unresponsive handshake at the configured timeout without retry", async () => {
+		const realTimeout = AbortSignal.timeout.bind(AbortSignal);
+		const timeout = spyOn(AbortSignal, "timeout").mockImplementation(() =>
+			realTimeout(10),
+		);
+		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+			(_input, init) =>
+				new Promise((_resolve, reject) => {
+					const signal = init?.signal;
+					if (!signal) throw new Error("Missing timeout signal");
+					signal.addEventListener("abort", () => reject(signal.reason), {
+						once: true,
+					});
+				}),
+		);
+		await expect(initExternalWallet(config)).rejects.toThrow(
+			"External BRC-100 signer readiness failed",
+		);
+		expect(timeout).toHaveBeenCalledWith(10_000);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+	});
+	it("uses the actual HTTPWalletJSON transport, headers and signer identity without startup writes", async () => {
+		const requests: {
+			path: string;
+			origin: string | null;
+			originator: string | null;
+			args: unknown;
+		}[] = [];
+		const signer = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			async fetch(req) {
+				const path = new URL(req.url).pathname;
+				requests.push({
+					path,
+					origin: req.headers.get("origin"),
+					originator: req.headers.get("originator"),
+					args: await req.json(),
+				});
+				if (path === "/getPublicKey")
+					return Response.json({ publicKey: identityKey });
+				if (path === "/listOutputs")
+					return Response.json({ totalOutputs: 0, outputs: [] });
+				if (path === "/createSignature")
+					return Response.json({ signature: [1, 2] });
+				return Response.json({ message: "unexpected call" }, { status: 500 });
+			},
+		});
+		try {
+			const result = await initExternalWallet({
+				...config,
+				url: `http://127.0.0.1:${signer.port}`,
+			});
+			expect(result.identityKey).toBe(identityKey);
+			expect(result.ctx.wallet).toBe(result.wallet);
+			expect(requests).toEqual([
+				{
+					path: "/getPublicKey",
+					origin: "http://bsv-mcp.local",
+					originator: "http://bsv-mcp.local",
+					args: { identityKey: true },
+				},
+			]);
+			await result.ctx.wallet.listOutputs({ basket: "default" });
+			await result.ctx.wallet.createSignature({
+				data: [1],
+				protocolID: [2, "test protocol"],
+				keyID: "test",
+			});
+			await destroyWallet();
+			expect(requests.map((request) => request.path)).toEqual([
+				"/getPublicKey",
+				"/listOutputs",
+				"/createSignature",
+			]);
+			// MCP teardown does not stop the externally owned signer.
+			expect(
+				(await result.wallet.getPublicKey({ identityKey: true })).publicKey,
+			).toBe(identityKey);
+		} finally {
+			await signer.stop(true);
+		}
+	});
+	it("failed readiness never loads/generates keys or provisions a node wallet, and does not retry", async () => {
+		const generate = spyOn(PrivateKey, "fromRandom");
+		const loadKeys = spyOn(SecureKeyManager.prototype, "loadKeys");
+		const provision = spyOn(nodeWallet, "createNodeWallet");
+		const fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("signer unavailable"),
+		);
+		const loader = mock(async () => {
+			throw new Error("local keys must never load");
+		});
+		expect(await initializeKeysForWalletMode(config, loader)).toBeUndefined();
+		await expect(initExternalWallet(config)).rejects.toThrow(
+			"External BRC-100 signer readiness failed",
+		);
+		expect(loader).not.toHaveBeenCalled();
+		expect(generate).not.toHaveBeenCalled();
+		expect(loadKeys).not.toHaveBeenCalled();
+		expect(provision).not.toHaveBeenCalled();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const options = fetchSpy.mock.calls[0]?.[1];
+		expect(options?.signal).toBeInstanceOf(AbortSignal);
+		expect(options?.redirect).toBe("error");
+	});
+});

--- a/utils/externalWalletConfig.ts
+++ b/utils/externalWalletConfig.ts
@@ -1,0 +1,89 @@
+/** Explicit signer selection must happen before any local key access. */
+export interface ExternalWalletConfig {
+	url: string;
+	originator: string;
+}
+
+export function readExternalWalletConfig(
+	env: Record<string, string | undefined> = process.env,
+): ExternalWalletConfig | undefined {
+	const raw = env.BRC100_WALLET_URL;
+	if (raw === undefined) {
+		if (env.BRC100_WALLET_ORIGINATOR !== undefined) {
+			throw new Error("BRC100_WALLET_ORIGINATOR requires BRC100_WALLET_URL");
+		}
+		return undefined;
+	}
+	for (const name of ["PRIVATE_KEY_WIF", "IDENTITY_KEY_WIF"]) {
+		if (env[name] !== undefined) {
+			throw new Error(
+				`BRC100_WALLET_URL conflicts with ${name}; select one wallet identity`,
+			);
+		}
+	}
+	if (env.USE_DROPLIT_API === "true") {
+		throw new Error("BRC100_WALLET_URL conflicts with USE_DROPLIT_API");
+	}
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		throw new Error("BRC100_WALLET_URL must be a valid signer RPC URL");
+	}
+	const loopback =
+		url.hostname === "localhost" ||
+		url.hostname === "[::1]" ||
+		/^127\.(?:\d{1,3}\.){2}\d{1,3}$/.test(url.hostname);
+	if (
+		!raw ||
+		raw !== raw.trim() ||
+		/[\\\s@?]/.test(raw) ||
+		url.username ||
+		url.password ||
+		raw.includes("#") ||
+		url.search ||
+		!(url.protocol === "https:" || (url.protocol === "http:" && loopback))
+	) {
+		throw new Error(
+			"BRC100_WALLET_URL requires HTTPS or HTTP loopback, without credentials, queries or fragments",
+		);
+	}
+	const originator = env.BRC100_WALLET_ORIGINATOR ?? "bsv-mcp.local";
+	let origin: URL;
+	try {
+		origin = new URL(
+			originator.includes("://") ? originator : `http://${originator}`,
+		);
+	} catch {
+		throw new Error(
+			"BRC100_WALLET_ORIGINATOR must be a domain or HTTP(S) origin",
+		);
+	}
+	if (
+		!originator ||
+		/[\s\\]/.test(originator) ||
+		originator.length >= 250 ||
+		!["http:", "https:"].includes(origin.protocol) ||
+		origin.username ||
+		origin.password ||
+		origin.pathname !== "/" ||
+		origin.search ||
+		/[#?@]/.test(originator) ||
+		!/^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*|\[::1\])$/i.test(
+			origin.hostname,
+		) ||
+		origin.hostname.toLowerCase() === "admin.bsv-mcp.internal"
+	) {
+		throw new Error(
+			"BRC100_WALLET_ORIGINATOR must be a non-admin domain or HTTP(S) origin without credentials, path, query or fragment",
+		);
+	}
+	return { url: url.toString().replace(/\/$/, ""), originator };
+}
+
+export async function initializeKeysForWalletMode<T>(
+	external: ExternalWalletConfig | undefined,
+	loadLocalKeys: () => Promise<T>,
+): Promise<T | undefined> {
+	return external ? undefined : loadLocalKeys();
+}

--- a/utils/walletInit.ts
+++ b/utils/walletInit.ts
@@ -13,8 +13,15 @@ import {
 	type NodeWalletResult,
 	type OneSatServices,
 } from "@1sat/wallet-node";
-import { PrivateKey, type WalletInterface } from "@bsv/sdk";
+import { OneSatServices as ExternalServices } from "@1sat/wallet-remote";
+import {
+	HTTPWalletJSON,
+	PrivateKey,
+	PublicKey,
+	type WalletInterface,
+} from "@bsv/sdk";
 import { WalletPermissionsManager } from "@bsv/wallet-toolbox/out/src/index.client.js";
+import type { ExternalWalletConfig } from "./externalWalletConfig";
 import { redactKeyMaterial } from "./redact";
 import {
 	handleSpendingAuthorization,
@@ -66,9 +73,7 @@ export interface WalletInitResult {
 	destroy: () => Promise<void>;
 }
 
-let activeResult:
-	| (NodeWalletResult & { ctx: OneSatContext; depositAddress: string })
-	| null = null;
+let activeResult: Pick<NodeWalletResult, "destroy"> | null = null;
 
 /**
  * Initialize the BRC-100 remote wallet.
@@ -142,7 +147,7 @@ export async function initWallet(
 			console.error("[wallet] message box sync failed:", err);
 		});
 
-	activeResult = { ...result, ctx, depositAddress };
+	activeResult = result;
 
 	return {
 		wallet: wpm,
@@ -151,6 +156,60 @@ export async function initWallet(
 		depositAddress,
 		destroy: result.destroy,
 	};
+}
+
+/**
+ * Connect to an existing signer without keys, local storage or permission wrappers.
+ * The timeout also bounds response body consumption; requests are never retried.
+ */
+export async function initExternalWallet(
+	config: ExternalWalletConfig,
+	chain: "main" | "test" = "main",
+): Promise<{
+	wallet: WalletInterface;
+	ctx: OneSatContext;
+	services: OneSatServices;
+	identityKey: string;
+	destroy: () => Promise<void>;
+}> {
+	const httpClient = ((input, init) =>
+		fetch(input, {
+			...init,
+			redirect: "error",
+			signal: init?.signal
+				? AbortSignal.any([init.signal, AbortSignal.timeout(10_000)])
+				: AbortSignal.timeout(10_000),
+		})) as typeof fetch;
+	const wallet = new HTTPWalletJSON(config.originator, config.url, httpClient);
+	let identityKey: string;
+	try {
+		const identity = await wallet.getPublicKey({ identityKey: true });
+		if (!/^(02|03)[0-9a-f]{64}$/i.test(identity.publicKey)) {
+			throw new Error(
+				"Signer returned an invalid compressed identity public key",
+			);
+		}
+		PublicKey.fromString(identity.publicKey);
+		identityKey = identity.publicKey;
+	} catch (error) {
+		throw new Error(
+			"External BRC-100 signer readiness failed. Check BRC100_WALLET_URL and approve identity access in the signer. This must be SDK signer RPC, not 1sat serve wallet storage RPC. No local wallet was created.",
+			{ cause: error },
+		);
+	}
+	// These are API clients only: construction does not provision wallet storage.
+	const services = new ExternalServices(chain, process.env.ONESAT_API_URL);
+	const dataDir = join(homedir(), ".bsv-mcp");
+	const ctx = createContext(wallet, {
+		services,
+		chain,
+		dataDir,
+		log: (entry) => writeAuditLog(dataDir, entry),
+	});
+	// This connection owns no signer resources. Never destroy the remote wallet.
+	const destroy = async () => {};
+	activeResult = { destroy };
+	return { wallet, ctx, services, identityKey, destroy };
 }
 
 /**


### PR DESCRIPTION
Connects BSV MCP to an existing BRC-100 HTTP signer without local key loading or wallet-storage provisioning. Adds connected-wallet sponsor access, push and fund tools alongside ordinary wallet tools. Permission flags reach the signer, sponsor authentication cannot create a payment, ambiguous writes are not replayed, and legacy taps preserve requested amounts.

Prepares bsv-mcp 0.3.1. Validation: 71 targeted tests and full build pass; independent reviews approved signer and sponsor units. A real local HTTP signer and isolated Go Droplit backend confirmed the actual client authenticates as the same wallet. No transactions broadcast.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791257070&installation_model_id=435537&pr_number=7&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F7&signature=248c80bf23763ec1f81c64817602bd3ff130713fe8113b00e18d85480f0fa2e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->