### PR TITLE
Complete Sigma delegation with the existing agent wallet

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "bsv-mcp",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Bitcoin SV MCP server with interactive dashboard — Explorer, Wallet, and Ordinals tabs via MCP Apps. Tools for price lookup, transaction decoding, address lookup, wallet management, NFT marketplace, and identity.",
 	"author": {
 		"name": "rohenaz",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # BSV MCP Server Changelog
 
+## [0.3.2] - 2026-09-06
+
+### Added
+- Reveal a human-issued Sigma delegation with the connected agent wallet, using standard certificate acquisition and proof.
+- Reject redirects, automatic payments, and ambiguous mutation retries; submit only verifier-specific keys.
+
 ## [0.3.1] - 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -912,3 +912,44 @@ BRC-105 payment handling cannot spend funds; a 402 requires human review. Struct
 available quota reset information is retained. `unknown_outcome` means reconcile
 transaction/history before retrying; no idempotency-key support is claimed.
 The legacy `USE_DROPLIT_API=true` wallet mode remains available separately.
+
+
+### Reveal a Sigma agent delegation with the connected wallet
+
+After the human owner binds this agent wallet and issues its BRC-169 delegation,
+copy the owner's complete handoff JSON into `wallet_revealDelegation`:
+
+- `sigmaOrigin`: the intended Sigma HTTPS origin (HTTP is allowed only for loopback testing).
+- `handoffJSON`: the owner's JSON containing `certificate`, `subjectKeyring`, `revealTo`, and `revelationPath`.
+
+The explicit tool invocation acquires the certificate into the connected wallet,
+proves all restrictions to the named Sigma verifier, and POSTs only that verifier's
+keyring. Use the same wallet that supplied the bound identity; its Ed25519 agent
+token cannot perform this step. The encrypted subject keyring stays with the agent
+and is never included in the HTTP request or tool result. This does not grant
+Droplit sponsor permission. No automatic payments, redirects, or POST retries are
+allowed. On `outcome_unknown`, ask the owner to refresh delegation status before
+trying again; certificate acquisition may already have succeeded.
+
+For a **local 1Sat CLI wallet** used throughout binding, the existing commands
+provide the same operation. Save the owner package as `handoff.json`, then:
+
+```sh
+bun -e 'const h=await Bun.file("handoff.json").json(),c=h.certificate; await Bun.write("acquire.json",JSON.stringify({acquisitionProtocol:"direct",type:c.type,certifier:c.certifier,fields:c.fields,serialNumber:c.serialNumber,revocationOutpoint:c.revocationOutpoint,signature:c.signature,keyringRevealer:"certifier",keyringForSubject:h.subjectKeyring})); await Bun.write("prove.json",JSON.stringify({certificate:c,fieldsToReveal:Object.keys(c.fields),verifier:h.revealTo}));'
+1sat wallet acquire-certificate "$(cat acquire.json)" --json
+1sat wallet prove-certificate "$(cat prove.json)" --json > proof.json
+bun -e 'const p=await Bun.file("proof.json").json(); if(!p.keyringForVerifier) throw new Error("Missing verifier keyring"); await Bun.write("revelation.json",JSON.stringify({keyring:p.keyringForVerifier}));'
+```
+
+Set `SIGMA_ORIGIN` to the intended Sigma origin and `REVELATION_PATH` to the
+owner's `/api/agents/{agentId}/delegations/{encodedSerialNumber}/revelation` path;
+percent-encode the base64 serial number as one path segment. Then:
+
+```sh
+1sat authfetch POST "${SIGMA_ORIGIN}${REVELATION_PATH}" --body @revelation.json --json
+```
+
+Use `@1sat/cli` 0.0.110 or later for stale-session mutation replay protection.
+Keep the same configured wallet and chain for every command. This CLI alternative
+does not use the MCP external wallet connection. The endpoint does not require a
+payment; do not add `--yes` to work around an unexpected 402.

--- a/dist/index.js
+++ b/dist/index.js
@@ -207971,9 +207971,9 @@ var require_vary = __commonJS((exports, module) => {
     if (!field) {
       throw new TypeError("field argument is required");
     }
-    var fields = !Array.isArray(field) ? parse8(String(field)) : field;
-    for (var j5 = 0;j5 < fields.length; j5++) {
-      if (!FIELD_NAME_REGEXP.test(fields[j5])) {
+    var fields2 = !Array.isArray(field) ? parse8(String(field)) : field;
+    for (var j5 = 0;j5 < fields2.length; j5++) {
+      if (!FIELD_NAME_REGEXP.test(fields2[j5])) {
         throw new TypeError("field argument contains an invalid header name");
       }
     }
@@ -207982,14 +207982,14 @@ var require_vary = __commonJS((exports, module) => {
     }
     var val = header;
     var vals = parse8(header.toLowerCase());
-    if (fields.indexOf("*") !== -1 || vals.indexOf("*") !== -1) {
+    if (fields2.indexOf("*") !== -1 || vals.indexOf("*") !== -1) {
       return "*";
     }
-    for (var i = 0;i < fields.length; i++) {
-      var fld = fields[i].toLowerCase();
+    for (var i = 0;i < fields2.length; i++) {
+      var fld = fields2[i].toLowerCase();
       if (vals.indexOf(fld) === -1) {
         vals.push(fld);
-        val = val ? val + ", " + fields[i] : fields[i];
+        val = val ? val + ", " + fields2[i] : fields2[i];
       }
     }
     return val;
@@ -213168,13 +213168,13 @@ var require_StorageKnex = __commonJS((exports) => {
         delete e2.certificateId;
       if (e2.logger != null)
         delete e2.logger;
-      const fields = e2.fields;
+      const fields2 = e2.fields;
       if (e2.fields != null)
         delete e2.fields;
       const [id] = await this.toDb(trx)("certificates").insert(e2);
       certificate.certificateId = id;
-      if (fields != null) {
-        for (const field of fields) {
+      if (fields2 != null) {
+        for (const field of fields2) {
           field.certificateId = id;
           field.userId = certificate.userId;
           await this.insertCertificateField(field, trx);
@@ -227862,11 +227862,11 @@ var require_querycompiler = __commonJS((exports, module) => {
     _preValidate() {
       const method = this.method;
       const verb = hasOwn(methodAliases, method) ? methodAliases[method] : method;
-      const invalid = this.invalidClauses[verb];
-      if (!invalid)
+      const invalid2 = this.invalidClauses[verb];
+      if (!invalid2)
         return;
-      for (let i = 0;i < invalid.length; i++) {
-        const clause = invalid[i];
+      for (let i = 0;i < invalid2.length; i++) {
+        const clause = invalid2[i];
         const hasNonEmptyGrouped = hasOwn(this.grouped, clause) && this.grouped[clause].length > 0;
         const hasNonEmptySingle = hasOwn(this.single, clause) && this.single[clause] != null;
         if (hasNonEmptyGrouped || hasNonEmptySingle) {
@@ -236146,10 +236146,10 @@ var require_mysql = __commonJS((exports, module) => {
           return;
         }
         const queryOptions = Object.assign({ sql: obj.sql }, obj.options);
-        connection.query(queryOptions, obj.bindings, function(err, rows, fields) {
+        connection.query(queryOptions, obj.bindings, function(err, rows, fields2) {
           if (err)
             return rejecter(err);
-          obj.response = [rows, fields];
+          obj.response = [rows, fields2];
           resolver(obj);
         });
       });
@@ -236160,9 +236160,9 @@ var require_mysql = __commonJS((exports, module) => {
       const { response } = obj;
       const { method } = obj;
       const rows = response[0];
-      const fields = response[1];
+      const fields2 = response[1];
       if (obj.output)
-        return obj.output.call(runner, rows, fields);
+        return obj.output.call(runner, rows, fields2);
       switch (method) {
         case "select":
           return rows;
@@ -236439,9 +236439,9 @@ var require_mariadb = __commonJS((exports, module) => {
         return;
       if (obj.returning) {
         const rows = obj.response[0];
-        const fields = obj.response[1];
+        const fields2 = obj.response[1];
         if (obj.output) {
-          return obj.output.call(runner, rows, fields);
+          return obj.output.call(runner, rows, fields2);
         }
         return rows;
       }
@@ -242385,8 +242385,8 @@ var require_ShamirWalletManager = __commonJS((exports) => {
       await this.entropyCollector.collectFromBrowser(element, onProgress);
     }
     generateUserIdHash(privateKey) {
-      const publicKey = privateKey.toPublicKey().toString();
-      const hash2 = sdk_1.Hash.sha256(sdk_1.Utils.toArray(publicKey, "utf8"));
+      const publicKey2 = privateKey.toPublicKey().toString();
+      const hash2 = sdk_1.Hash.sha256(sdk_1.Utils.toArray(publicKey2, "utf8"));
       return sdk_1.Utils.toHex(hash2);
     }
     async createNewWallet(authPayload, onUserSharesReady) {
@@ -244852,13 +244852,13 @@ var init_storage_pg = __esm(() => {
         e2.certificateId = undefined;
       if (e2.logger)
         e2.logger = undefined;
-      const fields = e2.fields;
+      const fields2 = e2.fields;
       if (e2.fields)
         e2.fields = undefined;
       const id = await this.insertRow("certificates", e2, trx);
       certificate.certificateId = id;
-      if (fields) {
-        for (const field of fields) {
+      if (fields2) {
+        for (const field of fields2) {
           field.certificateId = id;
           field.userId = certificate.userId;
           await this.insertCertificateField(field, trx);
@@ -256042,7 +256042,7 @@ var package_default = {
   name: "bsv-mcp",
   module: "dist/index.js",
   type: "module",
-  version: "0.3.1",
+  version: "0.3.2",
   license: "MIT",
   author: "satchmo",
   description: "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",
@@ -295163,7 +295163,7 @@ var package_default2 = {
   name: "bsv-mcp",
   module: "dist/index.js",
   type: "module",
-  version: "0.3.1",
+  version: "0.3.2",
   license: "MIT",
   author: "satchmo",
   description: "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",
@@ -297158,6 +297158,195 @@ function registerRefreshUtxosTool(server, ctx) {
   });
 }
 
+// utils/revealDelegation.ts
+init_mod2();
+var publicKey = exports_external.string().regex(/^(02|03)[a-f0-9]{64}$/);
+var base643 = exports_external.string().min(4).max(16384).regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/);
+var fields = exports_external.record(exports_external.string().min(1).max(49), base643).refine((v7) => Object.keys(v7).length > 0 && Object.keys(v7).length <= 32);
+var handoffSchema = exports_external.object({
+  certificate: exports_external.object({
+    type: exports_external.literal("30kchAJIGfLxzCNloCJNLI3AtkgA8UbkxlXU2Cj4PpA="),
+    serialNumber: base643.refine((v7) => Buffer.from(v7, "base64").length === 32),
+    subject: publicKey,
+    certifier: publicKey,
+    revocationOutpoint: exports_external.string().regex(/^[a-f0-9]{64}\.\d{1,10}$/),
+    signature: exports_external.string().regex(/^(?:[a-f0-9]{2}){8,72}$/),
+    fields
+  }).strict(),
+  subjectKeyring: fields,
+  revealTo: publicKey,
+  revelationPath: exports_external.string().max(512)
+}).strict();
+
+class RevelationError extends Error {
+  code;
+  status;
+  constructor(code, message, status) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+function invalid() {
+  throw new RevelationError("invalid_handoff", "Provide a valid Sigma origin and the owner's BRC-169 handoff.");
+}
+function parseHandoff(origin, handoffJSON) {
+  if (handoffJSON.length > 131072 || !/^https?:\/\/[^/?#\\]+\/?$/.test(origin))
+    invalid();
+  const url3 = new URL(origin);
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url3.hostname);
+  if (url3.username || url3.password || url3.protocol !== "https:" && !(url3.protocol === "http:" && loopback))
+    invalid();
+  const h5 = handoffSchema.parse(JSON.parse(handoffJSON));
+  for (const key of [
+    h5.certificate.subject,
+    h5.certificate.certifier,
+    h5.revealTo
+  ]) {
+    if (!PublicKey.fromString(key).validate())
+      invalid();
+  }
+  const match = /^\/api\/agents\/([A-Za-z0-9_-]{1,128})\/delegations\/(.+)\/revelation$/.exec(h5.revelationPath);
+  if (!match || decodeURIComponent(match[2]) !== h5.certificate.serialNumber)
+    invalid();
+  if (Object.keys(h5.subjectKeyring).sort().join(`
+`) !== Object.keys(h5.certificate.fields).sort().join(`
+`))
+    invalid();
+  return {
+    h: h5,
+    endpoint: `${url3.origin}/api/agents/${encodeURIComponent(match[1])}/delegations/${encodeURIComponent(h5.certificate.serialNumber)}/revelation`,
+    origin: url3.origin
+  };
+}
+async function revealDelegation(wallet5, sigmaOrigin, handoffJSON) {
+  let input;
+  try {
+    input = parseHandoff(sigmaOrigin, handoffJSON);
+  } catch {
+    invalid();
+  }
+  const { h: h5, endpoint, origin } = input;
+  const c6 = h5.certificate;
+  try {
+    const { publicKey: identity6 } = await wallet5.getPublicKey({
+      identityKey: true
+    });
+    if (identity6 !== c6.subject)
+      throw new RevelationError("subject_mismatch", "The connected wallet is not this delegation's subject.");
+    const certificate = new Certificate(c6.type, c6.serialNumber, c6.subject, c6.certifier, c6.revocationOutpoint, c6.fields, c6.signature);
+    if (!await certificate.verify())
+      invalid();
+  } catch (error53) {
+    if (error53 instanceof RevelationError)
+      throw error53;
+    throw new RevelationError("invalid_certificate", "Could not verify the certificate and connected wallet identity.");
+  }
+  let keyring;
+  try {
+    await wallet5.acquireCertificate({
+      ...c6,
+      acquisitionProtocol: "direct",
+      keyringRevealer: "certifier",
+      keyringForSubject: h5.subjectKeyring
+    });
+    const proof = await wallet5.proveCertificate({
+      certificate: c6,
+      fieldsToReveal: Object.keys(c6.fields),
+      verifier: h5.revealTo
+    });
+    keyring = fields.parse(proof.keyringForVerifier);
+  } catch {
+    throw new RevelationError("wallet_proof_failed", "The wallet could not acquire or prove this delegation. Check its certificate store before retrying.");
+  }
+  return postRevelation(wallet5, origin, endpoint, keyring);
+}
+async function postRevelation(wallet5, origin, endpoint, keyring) {
+  const guarded = new Proxy(wallet5, {
+    get(target, property) {
+      if (property === "createAction" || property === "signAction")
+        return async () => {
+          throw new RevelationError("payment_required", "Sigma revelation must not require a payment.", 402);
+        };
+      const value2 = Reflect.get(target, property, target);
+      return typeof value2 === "function" ? value2.bind(target) : value2;
+    }
+  });
+  let refusal;
+  const guardedFetch = async (url3, init) => {
+    if (String(url3) !== `${origin}/.well-known/auth` && String(url3) !== endpoint) {
+      refusal = new RevelationError("unexpected_endpoint", "Sigma authentication requested an unexpected endpoint.");
+      throw refusal;
+    }
+    const response = await fetch(url3, { ...init, redirect: "error" });
+    if ([401, 402, 403, 409, 422, 429].includes(response.status)) {
+      refusal = new RevelationError(response.status === 402 ? "payment_required" : "request_rejected", "Sigma rejected revelation. Check owner delegation status before retrying.", response.status);
+      throw refusal;
+    }
+    return response;
+  };
+  const transport = new SimplifiedFetchTransport(origin, guardedFetch);
+  const sessions = new SessionManager;
+  const auth5 = new AuthFetch(guarded, undefined, sessions);
+  const peer = new Peer(guarded, transport, undefined, sessions);
+  try {
+    await peer.ready;
+    auth5.peers[origin] = { peer, pendingCertificateRequests: [] };
+    const response = await auth5.fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keyring }),
+      retryCounter: 1,
+      paymentRetryAttempts: 1
+    });
+    if (!response.ok)
+      throw new RevelationError("request_rejected", "Sigma rejected revelation. Check owner delegation status before retrying.", response.status);
+    return { status: "revealed", httpStatus: response.status };
+  } catch (error53) {
+    if (refusal)
+      throw refusal;
+    if (error53 instanceof RevelationError)
+      throw error53;
+    throw new RevelationError("outcome_unknown", "Revelation was not confirmed. Ask the owner to refresh delegation status before retrying; no automatic replay was attempted.");
+  }
+}
+
+// tools/wallet/revealDelegation.ts
+function registerRevealDelegationTool(server, ctx) {
+  server.registerTool("wallet_revealDelegation", {
+    description: "Receive the human owner's BRC-169 certificate handoff, acquire and prove it with this connected agent wallet, and reveal its restrictions to the specified Sigma verifier. Imports a certificate and activates its existing delegation. Never pays, broadcasts, follows redirects, or retries an ambiguous POST. The subject keyring stays with the wallet.",
+    inputSchema: {
+      sigmaOrigin: exports_external.string().max(2048).describe("Explicit Sigma HTTPS origin, or HTTP loopback for local testing"),
+      handoffJSON: exports_external.string().max(131072).describe("JSON package copied by the owner: certificate, subjectKeyring, revealTo, revelationPath")
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    }
+  }, async ({ sigmaOrigin, handoffJSON }) => {
+    try {
+      if (!ctx)
+        throw new RevelationError("wallet_unavailable", "Connect the agent's existing wallet first.");
+      const data = await revealDelegation(ctx.wallet, sigmaOrigin, handoffJSON);
+      return { ...createSuccessResponse(data), structuredContent: data };
+    } catch (error53) {
+      const failure = error53 instanceof RevelationError ? error53 : new RevelationError("revelation_failed", "Delegation revelation failed. Check wallet and owner status before retrying.");
+      const data = {
+        error: failure.code,
+        message: failure.message,
+        ...failure.status === undefined ? {} : { status: failure.status }
+      };
+      return {
+        ...createSuccessResponse(data),
+        structuredContent: data,
+        isError: true
+      };
+    }
+  });
+}
+
 // tools/wallet/sendAllBsv.ts
 var sendAllBsvArgsSchema = exports_external.object({
   destination: exports_external.string().describe("Destination P2PKH address to send all funds to")
@@ -297661,6 +297850,7 @@ function registerWalletTools(server, wallet5, config2) {
   registerRefreshUtxosTool(server, config2.ctx);
   registerWalletGetBalanceTool(server, config2.ctx);
   registerBrc100Tools(server, config2.ctx);
+  registerRevealDelegationTool(server, config2.ctx);
   if (config2.enableA2bTools && wallet5 && config2.identityPk) {
     registerA2bPublishMcpTool(server, wallet5, config2.identityPk, {
       disableBroadcasting: config2.disableBroadcasting
@@ -297846,9 +298036,9 @@ class Wallet {
     if (!currentPaymentKey) {
       throw new Error("No payment key available to derive public key.");
     }
-    const publicKey = currentPaymentKey.toPublicKey();
+    const publicKey2 = currentPaymentKey.toPublicKey();
     return {
-      publicKey: publicKey.toDER("hex")
+      publicKey: publicKey2.toDER("hex")
     };
   }
   async sendToAddress(address, amountSatoshis) {
@@ -298089,9 +298279,9 @@ class Wallet2 {
     if (!currentPaymentKey) {
       throw new Error("No payment key available to derive public key.");
     }
-    const publicKey = currentPaymentKey.toPublicKey();
+    const publicKey2 = currentPaymentKey.toPublicKey();
     return {
-      publicKey: publicKey.toDER("hex")
+      publicKey: publicKey2.toDER("hex")
     };
   }
   async sendToAddress(address, amountSatoshis) {
@@ -298252,8 +298442,8 @@ class DroplitClient2 {
   async getIdentityKey() {
     if (!this.wallet)
       throw new DroplitError2("authentication_required", "Configure a Droplit wallet identity.");
-    const { publicKey } = await this.wallet.getPublicKey({ identityKey: true });
-    return publicKey;
+    const { publicKey: publicKey2 } = await this.wallet.getPublicKey({ identityKey: true });
+    return publicKey2;
   }
   get faucetPath() {
     return `/faucet/${encodeURIComponent(this.config.faucetName)}`;
@@ -301203,13 +301393,13 @@ class StorageBunSqlite extends import_StorageProvider.StorageProvider {
       e2.certificateId = undefined;
     if (e2.logger)
       e2.logger = undefined;
-    const fields = e2.fields;
+    const fields2 = e2.fields;
     if (e2.fields)
       e2.fields = undefined;
     const id = this.insertRow("certificates", e2);
     certificate.certificateId = id;
-    if (fields) {
-      for (const field of fields) {
+    if (fields2) {
+      for (const field of fields2) {
         field.certificateId = id;
         field.userId = certificate.userId;
         await this.insertCertificateField(field, trx);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bsv-mcp",
 	"module": "dist/index.js",
 	"type": "module",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"license": "MIT",
 	"author": "satchmo",
 	"description": "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",

--- a/tools/wallet/revealDelegation.ts
+++ b/tools/wallet/revealDelegation.ts
@@ -1,0 +1,74 @@
+import type { OneSatContext } from "@1sat/actions";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+	RevelationError,
+	revealDelegation,
+} from "../../utils/revealDelegation";
+import { createSuccessResponse } from "../utils/errorHandler";
+
+export function registerRevealDelegationTool(
+	server: McpServer,
+	ctx?: OneSatContext,
+) {
+	server.registerTool(
+		"wallet_revealDelegation",
+		{
+			description:
+				"Receive the human owner's BRC-169 certificate handoff, acquire and prove it with this connected agent wallet, and reveal its restrictions to the specified Sigma verifier. Imports a certificate and activates its existing delegation. Never pays, broadcasts, follows redirects, or retries an ambiguous POST. The subject keyring stays with the wallet.",
+			inputSchema: {
+				sigmaOrigin: z
+					.string()
+					.max(2048)
+					.describe(
+						"Explicit Sigma HTTPS origin, or HTTP loopback for local testing",
+					),
+				handoffJSON: z
+					.string()
+					.max(131072)
+					.describe(
+						"JSON package copied by the owner: certificate, subjectKeyring, revealTo, revelationPath",
+					),
+			},
+			annotations: {
+				readOnlyHint: false,
+				destructiveHint: false,
+				idempotentHint: false,
+				openWorldHint: true,
+			},
+		},
+		async ({ sigmaOrigin, handoffJSON }) => {
+			try {
+				if (!ctx)
+					throw new RevelationError(
+						"wallet_unavailable",
+						"Connect the agent's existing wallet first.",
+					);
+				const data = await revealDelegation(
+					ctx.wallet,
+					sigmaOrigin,
+					handoffJSON,
+				);
+				return { ...createSuccessResponse(data), structuredContent: data };
+			} catch (error) {
+				const failure =
+					error instanceof RevelationError
+						? error
+						: new RevelationError(
+								"revelation_failed",
+								"Delegation revelation failed. Check wallet and owner status before retrying.",
+							);
+				const data = {
+					error: failure.code,
+					message: failure.message,
+					...(failure.status === undefined ? {} : { status: failure.status }),
+				};
+				return {
+					...createSuccessResponse(data),
+					structuredContent: data,
+					isError: true,
+				};
+			}
+		},
+	);
+}

--- a/tools/wallet/tools.ts
+++ b/tools/wallet/tools.ts
@@ -19,6 +19,7 @@ import { registerOpnsDeregisterTool } from "./opnsDeregister";
 import { registerOpnsRegisterTool } from "./opnsRegister";
 import { registerPurchaseListingTool } from "./purchaseListing";
 import { registerRefreshUtxosTool } from "./refreshUtxos";
+import { registerRevealDelegationTool } from "./revealDelegation";
 import { registerSendAllBsvTool } from "./sendAllBsv";
 import { registerSendBsvTool } from "./sendBsv";
 import { registerSignBsmTool } from "./signBsm";
@@ -58,6 +59,7 @@ export function registerWalletTools(
 
 	// Register full BRC-100 wallet interface
 	registerBrc100Tools(server, config.ctx);
+	registerRevealDelegationTool(server, config.ctx);
 
 	// A2B tools have to be explicitly enabled
 	if (config.enableA2bTools && wallet && config.identityPk) {

--- a/utils/revealDelegation.test.ts
+++ b/utils/revealDelegation.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import {
+	AuthFetch,
+	KeyDeriver,
+	MasterCertificate,
+	Peer,
+	PrivateKey,
+	ProtoWallet,
+	type SimplifiedFetchTransport,
+	Utils,
+	VerifiableCertificate,
+	type WalletInterface,
+} from "@bsv/sdk";
+import { Wallet } from "@bsv/wallet-toolbox";
+import {
+	postRevelation,
+	RevelationError,
+	revealDelegation,
+} from "./revealDelegation";
+
+afterEach(() => mock.restore());
+const type = "30kchAJIGfLxzCNloCJNLI3AtkgA8UbkxlXU2Cj4PpA=";
+async function fixture() {
+	const principal = new ProtoWallet(PrivateKey.fromRandom());
+	const subjectKey = PrivateKey.fromRandom();
+	const identityKey = subjectKey.toPublicKey().toString();
+	const verifier = new ProtoWallet(PrivateKey.fromRandom());
+	const verifierKey = (await verifier.getPublicKey({ identityKey: true }))
+		.publicKey;
+	const master = await MasterCertificate.issueCertificateForSubject(
+		principal,
+		identityKey,
+		{
+			delegator: "@alice@example.test",
+			scope: "identity:read",
+			expiry: "2030-01-01T00:00:00.000Z",
+		},
+		type,
+		async () => `${"a".repeat(64)}.0`,
+		Utils.toBase64(Array(32).fill(255)),
+	);
+	if (!master.signature) throw new Error("Missing fixture signature");
+	const certificate = {
+		type: master.type,
+		serialNumber: master.serialNumber,
+		subject: master.subject,
+		certifier: master.certifier,
+		revocationOutpoint: master.revocationOutpoint,
+		fields: master.fields,
+		signature: master.signature,
+	};
+	type Stored = {
+		fields: Array<{ fieldName: string; fieldValue: string; masterKey: string }>;
+		[key: string]: unknown;
+	};
+	let stored: Stored = { fields: [] };
+	const insert = mock(async (value: Stored) => {
+		stored = value;
+	});
+	// Actual toolbox Wallet acquire/prove and crypto; only persistence is in memory.
+	const wallet = new Wallet({
+		chain: "test",
+		keyDeriver: new KeyDeriver(subjectKey),
+		storage: {
+			_authId: { identityKey },
+			insertCertificate: insert,
+			listCertificates: async () => ({
+				certificates: [
+					{
+						...stored,
+						fields: Object.fromEntries(
+							stored.fields.map((f) => [f.fieldName, f.fieldValue]),
+						),
+						keyring: Object.fromEntries(
+							stored.fields.map((f) => [f.fieldName, f.masterKey]),
+						),
+					},
+				],
+			}),
+		} as never,
+	});
+	const handoff = {
+		certificate,
+		subjectKeyring: master.masterKeyring,
+		revealTo: verifierKey,
+		revelationPath: `/api/agents/agent-123/delegations/${certificate.serialNumber}/revelation`,
+	};
+	return { wallet, verifier, handoff, insert };
+}
+
+test("real toolbox acquisition/proof reveals to verifier and sends only verifier keys", async () => {
+	const f = await fixture();
+	let sent: NonNullable<Parameters<AuthFetch["fetch"]>[1]> = {};
+	const request = spyOn(AuthFetch.prototype, "fetch").mockImplementation(
+		async (_url, config) => {
+			sent = config ?? {};
+			return new Response("untrusted body", { status: 200 });
+		},
+	);
+	expect(
+		await revealDelegation(
+			f.wallet,
+			"https://sigma.example",
+			JSON.stringify(f.handoff),
+		),
+	).toEqual({ status: "revealed", httpStatus: 200 });
+	expect(f.insert).toHaveBeenCalledTimes(1);
+	expect(request.mock.calls[0][0]).toBe(
+		`https://sigma.example/api/agents/agent-123/delegations/${encodeURIComponent(f.handoff.certificate.serialNumber)}/revelation`,
+	);
+	expect(sent.retryCounter).toBe(1);
+	const body = JSON.parse(sent.body);
+	expect(Object.keys(body)).toEqual(["keyring"]);
+	expect(JSON.stringify(body)).not.toContain(
+		JSON.stringify(f.handoff.subjectKeyring),
+	);
+	const c = f.handoff.certificate;
+	const proof = new VerifiableCertificate(
+		c.type,
+		c.serialNumber,
+		c.subject,
+		c.certifier,
+		c.revocationOutpoint,
+		c.fields,
+		body.keyring,
+		c.signature,
+	);
+	expect(await proof.decryptFields(f.verifier)).toEqual({
+		delegator: "@alice@example.test",
+		scope: "identity:read",
+		expiry: "2030-01-01T00:00:00.000Z",
+	});
+});
+
+test("subject mismatch and invalid origins fail before certificate import", async () => {
+	const f = await fixture();
+	const request = spyOn(AuthFetch.prototype, "fetch");
+	for (const origin of [
+		"http://sigma.example",
+		"https://x:y@sigma.example",
+		"https://sigma.example/path",
+		"https://sigma.example?x=1",
+		"https://sigma.example#x",
+		"https://sigma.example\\evil",
+	]) {
+		await expect(
+			revealDelegation(f.wallet, origin, JSON.stringify(f.handoff)),
+		).rejects.toMatchObject({ code: "invalid_handoff" });
+	}
+	const wrong = {
+		...f.handoff,
+		certificate: {
+			...f.handoff.certificate,
+			subject: PrivateKey.fromRandom().toPublicKey().toString(),
+		},
+	};
+	await expect(
+		revealDelegation(f.wallet, "https://sigma.example", JSON.stringify(wrong)),
+	).rejects.toMatchObject({ code: "subject_mismatch" });
+	expect(f.insert).not.toHaveBeenCalled();
+	expect(request).not.toHaveBeenCalled();
+});
+
+test("actual SDK stale-session recursion cannot replace guarded transport or resend", async () => {
+	const f = await fixture();
+	const send = spyOn(Peer.prototype, "toPeer").mockRejectedValue(
+		new Error("Session not found for nonce: stale"),
+	);
+	await expect(
+		postRevelation(
+			f.wallet,
+			"https://sigma.example",
+			"https://sigma.example/api/agents/a/delegations/b/revelation",
+			{},
+		),
+	).rejects.toMatchObject({ code: "outcome_unknown" });
+	expect(send).toHaveBeenCalledTimes(1);
+});
+
+test("authentication wallet blocks both payment methods and redacts errors", async () => {
+	const f = await fixture();
+	const create = spyOn(f.wallet, "createAction");
+	const sign = spyOn(f.wallet, "signAction");
+	spyOn(AuthFetch.prototype, "fetch").mockImplementation(async function (
+		this: AuthFetch,
+	) {
+		const wallet = Reflect.get(this, "wallet") as WalletInterface;
+		await expect(
+			wallet.signAction({ reference: "x", spends: {} }),
+		).rejects.toMatchObject({ code: "payment_required" });
+		await wallet.createAction({ description: "unexpected payment" });
+		return new Response();
+	});
+	await expect(
+		postRevelation(
+			f.wallet,
+			"https://sigma.example",
+			"https://sigma.example/api/agents/a/delegations/b/revelation",
+			{},
+		),
+	).rejects.toMatchObject({ code: "payment_required", status: 402 });
+	expect(create).not.toHaveBeenCalled();
+	expect(sign).not.toHaveBeenCalled();
+});
+
+for (const phase of ["handshake", "endpoint"])
+	test(`real SDK ${phase} refuses redirect without reaching target`, async () => {
+		const f = await fixture();
+		let requests = 0;
+		let followed = 0;
+		const target = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch() {
+				followed++;
+				return new Response("unexpected");
+			},
+		});
+		if (phase === "endpoint") {
+			spyOn(Peer.prototype, "toPeer").mockImplementation(async function (
+				this: Peer,
+				payload: number[],
+			) {
+				// Use the real configured SDK transport for the mutation; only skip the
+				// cryptographic handshake so this regression isolates endpoint redirects.
+				const transport = Reflect.get(
+					this,
+					"transport",
+				) as SimplifiedFetchTransport;
+				await transport.send({
+					messageType: "general",
+					version: "0.1",
+					identityKey: f.handoff.certificate.subject,
+					nonce: "n",
+					yourNonce: "y",
+					signature: [1],
+					payload,
+				});
+			});
+		}
+		const source = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch() {
+				requests++;
+				return new Response(null, {
+					status: 307,
+					headers: { Location: target.url.href },
+				});
+			},
+		});
+		try {
+			const origin = source.url.origin;
+			await expect(
+				postRevelation(
+					f.wallet,
+					origin,
+					`${origin}/api/agents/a/delegations/b/revelation`,
+					{},
+				),
+			).rejects.toMatchObject({ code: "outcome_unknown" });
+			expect(requests).toBe(1);
+			expect(followed).toBe(0);
+		} finally {
+			source.stop(true);
+			target.stop(true);
+		}
+	});
+
+test("actual SDK 402 processor cannot create a payment", async () => {
+	const f = await fixture();
+	const create = spyOn(f.wallet, "createAction");
+	const processor = Reflect.get(
+		AuthFetch.prototype,
+		"handlePaymentAndRetry",
+	) as (url: string, config: object, response: Response) => Promise<Response>;
+	spyOn(AuthFetch.prototype, "fetch").mockImplementation(async function (
+		this: AuthFetch,
+		url,
+		config,
+	) {
+		return processor.call(
+			this,
+			url,
+			config ?? {},
+			new Response(null, {
+				status: 402,
+				headers: {
+					"x-bsv-payment-version": "1.0",
+					"x-bsv-payment-satoshis-required": "25",
+					"x-bsv-auth-identity-key": f.handoff.revealTo,
+					"x-bsv-payment-derivation-prefix": "test-prefix",
+				},
+			}),
+		);
+	});
+	await expect(
+		postRevelation(
+			f.wallet,
+			"https://sigma.example",
+			"https://sigma.example/api/agents/a/delegations/b/revelation",
+			{},
+		),
+	).rejects.toMatchObject({ code: "payment_required", status: 402 });
+	expect(create).not.toHaveBeenCalled();
+});
+
+test("invalid certificate and path cannot import; transport errors do not echo secrets", async () => {
+	const f = await fixture();
+	for (const handoff of [
+		{
+			...f.handoff,
+			certificate: { ...f.handoff.certificate, signature: "3006020101020101" },
+		},
+		{
+			...f.handoff,
+			revelationPath: "//elsewhere/api/agents/a/delegations/b/revelation",
+		},
+		{
+			...f.handoff,
+			revelationPath: "/api/agents/a/delegations/wrong/revelation",
+		},
+	]) {
+		await expect(
+			revealDelegation(
+				f.wallet,
+				"https://sigma.example",
+				JSON.stringify(handoff),
+			),
+		).rejects.toBeInstanceOf(RevelationError);
+	}
+	expect(f.insert).not.toHaveBeenCalled();
+	spyOn(AuthFetch.prototype, "fetch").mockRejectedValue(
+		new Error("private body preview must not escape"),
+	);
+	try {
+		await postRevelation(
+			f.wallet,
+			"https://sigma.example",
+			"https://sigma.example/api/agents/a/delegations/b/revelation",
+			{},
+		);
+		throw new Error("expected failure");
+	} catch (error) {
+		expect(error).toMatchObject({ code: "outcome_unknown" });
+		expect(String(error)).not.toContain("private body");
+	}
+});

--- a/utils/revealDelegation.ts
+++ b/utils/revealDelegation.ts
@@ -1,0 +1,236 @@
+import {
+	AuthFetch,
+	Certificate,
+	Peer,
+	PublicKey,
+	SessionManager,
+	SimplifiedFetchTransport,
+	type WalletInterface,
+} from "@bsv/sdk";
+import { z } from "zod";
+
+const publicKey = z.string().regex(/^(02|03)[a-f0-9]{64}$/);
+const base64 = z
+	.string()
+	.min(4)
+	.max(16384)
+	.regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/);
+const fields = z
+	.record(z.string().min(1).max(49), base64)
+	.refine((v) => Object.keys(v).length > 0 && Object.keys(v).length <= 32);
+const handoffSchema = z
+	.object({
+		certificate: z
+			.object({
+				type: z.literal("30kchAJIGfLxzCNloCJNLI3AtkgA8UbkxlXU2Cj4PpA="),
+				serialNumber: base64.refine(
+					(v) => Buffer.from(v, "base64").length === 32,
+				),
+				subject: publicKey,
+				certifier: publicKey,
+				revocationOutpoint: z.string().regex(/^[a-f0-9]{64}\.\d{1,10}$/),
+				signature: z.string().regex(/^(?:[a-f0-9]{2}){8,72}$/),
+				fields,
+			})
+			.strict(),
+		subjectKeyring: fields,
+		revealTo: publicKey,
+		revelationPath: z.string().max(512),
+	})
+	.strict();
+
+export class RevelationError extends Error {
+	constructor(
+		readonly code: string,
+		message: string,
+		readonly status?: number,
+	) {
+		super(message);
+	}
+}
+
+function invalid(): never {
+	throw new RevelationError(
+		"invalid_handoff",
+		"Provide a valid Sigma origin and the owner's BRC-169 handoff.",
+	);
+}
+
+function parseHandoff(origin: string, handoffJSON: string) {
+	if (handoffJSON.length > 131072 || !/^https?:\/\/[^/?#\\]+\/?$/.test(origin))
+		invalid();
+	const url = new URL(origin);
+	const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+	if (
+		url.username ||
+		url.password ||
+		(url.protocol !== "https:" && !(url.protocol === "http:" && loopback))
+	)
+		invalid();
+	const h = handoffSchema.parse(JSON.parse(handoffJSON));
+	for (const key of [
+		h.certificate.subject,
+		h.certificate.certifier,
+		h.revealTo,
+	]) {
+		if (!PublicKey.fromString(key).validate()) invalid();
+	}
+	const match =
+		/^\/api\/agents\/([A-Za-z0-9_-]{1,128})\/delegations\/(.+)\/revelation$/.exec(
+			h.revelationPath,
+		);
+	if (!match || decodeURIComponent(match[2]) !== h.certificate.serialNumber)
+		invalid();
+	if (
+		Object.keys(h.subjectKeyring).sort().join("\n") !==
+		Object.keys(h.certificate.fields).sort().join("\n")
+	)
+		invalid();
+	return {
+		h,
+		endpoint: `${url.origin}/api/agents/${encodeURIComponent(match[1])}/delegations/${encodeURIComponent(h.certificate.serialNumber)}/revelation`,
+		origin: url.origin,
+	};
+}
+
+/** Uses the existing subject wallet. Master keys are never sent to Sigma. */
+export async function revealDelegation(
+	wallet: WalletInterface,
+	sigmaOrigin: string,
+	handoffJSON: string,
+) {
+	let input: ReturnType<typeof parseHandoff>;
+	try {
+		input = parseHandoff(sigmaOrigin, handoffJSON);
+	} catch {
+		invalid();
+	}
+	const { h, endpoint, origin } = input;
+	const c = h.certificate;
+	try {
+		const { publicKey: identity } = await wallet.getPublicKey({
+			identityKey: true,
+		});
+		if (identity !== c.subject)
+			throw new RevelationError(
+				"subject_mismatch",
+				"The connected wallet is not this delegation's subject.",
+			);
+		const certificate = new Certificate(
+			c.type,
+			c.serialNumber,
+			c.subject,
+			c.certifier,
+			c.revocationOutpoint,
+			c.fields,
+			c.signature,
+		);
+		if (!(await certificate.verify())) invalid();
+	} catch (error) {
+		if (error instanceof RevelationError) throw error;
+		throw new RevelationError(
+			"invalid_certificate",
+			"Could not verify the certificate and connected wallet identity.",
+		);
+	}
+	let keyring: Record<string, string>;
+	try {
+		await wallet.acquireCertificate({
+			...c,
+			acquisitionProtocol: "direct",
+			keyringRevealer: "certifier",
+			keyringForSubject: h.subjectKeyring,
+		});
+		const proof = await wallet.proveCertificate({
+			certificate: c,
+			fieldsToReveal: Object.keys(c.fields),
+			verifier: h.revealTo,
+		});
+		keyring = fields.parse(proof.keyringForVerifier);
+	} catch {
+		throw new RevelationError(
+			"wallet_proof_failed",
+			"The wallet could not acquire or prove this delegation. Check its certificate store before retrying.",
+		);
+	}
+	return postRevelation(wallet, origin, endpoint, keyring);
+}
+
+/** SDK public transport injection enforces redirect policy on handshake AND request. */
+export async function postRevelation(
+	wallet: WalletInterface,
+	origin: string,
+	endpoint: string,
+	keyring: Record<string, string>,
+) {
+	const guarded = new Proxy(wallet, {
+		get(target, property) {
+			if (property === "createAction" || property === "signAction")
+				return async () => {
+					throw new RevelationError(
+						"payment_required",
+						"Sigma revelation must not require a payment.",
+						402,
+					);
+				};
+			const value = Reflect.get(target, property, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+	let refusal: RevelationError | undefined;
+	const guardedFetch = (async (
+		url: Parameters<typeof fetch>[0],
+		init?: Parameters<typeof fetch>[1],
+	) => {
+		if (
+			String(url) !== `${origin}/.well-known/auth` &&
+			String(url) !== endpoint
+		) {
+			refusal = new RevelationError(
+				"unexpected_endpoint",
+				"Sigma authentication requested an unexpected endpoint.",
+			);
+			throw refusal;
+		}
+		const response = await fetch(url, { ...init, redirect: "error" });
+		if ([401, 402, 403, 409, 422, 429].includes(response.status)) {
+			refusal = new RevelationError(
+				response.status === 402 ? "payment_required" : "request_rejected",
+				"Sigma rejected revelation. Check owner delegation status before retrying.",
+				response.status,
+			);
+			throw refusal;
+		}
+		return response;
+	}) as typeof fetch;
+	const transport = new SimplifiedFetchTransport(origin, guardedFetch);
+	const sessions = new SessionManager();
+	const auth = new AuthFetch(guarded, undefined, sessions);
+	const peer = new Peer(guarded, transport, undefined, sessions);
+	try {
+		await peer.ready;
+		auth.peers[origin] = { peer, pendingCertificateRequests: [] };
+		const response = await auth.fetch(endpoint, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ keyring }),
+			retryCounter: 1,
+			paymentRetryAttempts: 1,
+		});
+		if (!response.ok)
+			throw new RevelationError(
+				"request_rejected",
+				"Sigma rejected revelation. Check owner delegation status before retrying.",
+				response.status,
+			);
+		// Return only a bounded acknowledgement; never echo an untrusted HTTP body.
+		return { status: "revealed", httpStatus: response.status };
+	} catch (error) {
+		if (refusal) throw refusal;
+		if (error instanceof RevelationError) throw error;
+		throw new RevelationError(
+			"outcome_unknown",
+			"Revelation was not confirmed. Ask the owner to refresh delegation status before retrying; no automatic replay was attempted.",
+		);
+	}
+}


### PR DESCRIPTION
An agent using an external BRC-100 wallet could acquire and prove its Sigma delegation certificate but could not deliver the verifier keyring with that same signer. Add wallet_revealDelegation to complete that handoff using the existing wallet and standard SDK certificate methods.

Validate the subject and certificate before importing, constrain the destination to Sigma's revelation route, send only verifier-specific keys, and reject redirects, automatic payments and ambiguous POST retries. Add executable guidance to the README.

Validation: all 105 tests pass (338 assertions), including real toolbox certificate acquisition/proof and verifier decryption, actual SDK handshake/endpoint redirect refusal, payment refusal and single-send enforcement. Independent review approved; all MCP builds and release preflight passed. Release bsv-mcp 0.3.2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791259987&installation_model_id=435537&pr_number=8&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F8&signature=ff2b07b2d15cc843667a23453a3dccb3ee2de0cefcbd1f643117913542443f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->