### PR TITLE
Fix staging sponsor approval links

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "bsv-mcp",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "Bitcoin SV MCP server with interactive dashboard — Explorer, Wallet, and Ordinals tabs via MCP Apps. Tools for price lookup, transaction decoding, address lookup, wallet management, NFT marketplace, and identity.",
 	"author": {
 		"name": "rohenaz",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # BSV MCP Server Changelog
 
+## [0.3.3] - 2026-09-06
+
+### Fixed
+- Honor `DROPLIT_SITE_URL` for sponsor approval links so staging requests reach the correct owner UI.
+- Build approval links from the configured sponsor and verified wallet identity; reject unsafe site origins.
+
 ## [0.3.2] - 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -884,6 +884,8 @@ BRC100_WALLET_URL=http://127.0.0.1:3321
 BRC100_WALLET_ORIGINATOR=bsv-mcp.local
 DROPLIT_API_URL=https://api.droplit.dev/droplit
 DROPLIT_FAUCET_NAME=your-sponsor-slug
+# Optional: set explicitly when the owner approval UI is hosted elsewhere.
+DROPLIT_SITE_URL=https://droplit.dev
 ```
 
 Set both sponsor values explicitly. The URL includes the server's configured
@@ -893,8 +895,15 @@ BRC-100 wallet contexts also support this sponsor pair. `1sat serve` exposes a
 wallet stack service; it is not itself a BRC-100 signer RPC endpoint.
 
 Call `droplit_getAccess` to inspect your own authorization and quotas. An
-`approval_required` response includes a `https://droplit.dev` link for manual
+`approval_required` response includes a link to `DROPLIT_SITE_URL` (default
+`https://droplit.dev`) for manual
 owner review. Do not automatically open, approve, or register to obtain access.
+The site URL must be an HTTPS origin (HTTP is allowed only for loopback),
+without credentials, a path, query, or fragment. For staging, set it to the
+trusted staging frontend origin independently of `DROPLIT_API_URL`. Approval
+links use the configured sponsor and authenticated wallet identity; a server
+response cannot redirect them to another site.
+
 Public status and public-key registration do not prove sponsor approval, and
 creating your own faucet requires funding rather than providing free credit.
 Missing quota kinds are unrestricted for authorized users; a configured zero

--- a/dist/index.js
+++ b/dist/index.js
@@ -256042,7 +256042,7 @@ var package_default = {
   name: "bsv-mcp",
   module: "dist/index.js",
   type: "module",
-  version: "0.3.2",
+  version: "0.3.3",
   license: "MIT",
   author: "satchmo",
   description: "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",
@@ -284877,6 +284877,15 @@ function registerUtilsTools(server) {
 
 // utils/droplit.ts
 init_mod2();
+function approvalSiteOrigin(value2 = "https://droplit.dev") {
+  const url3 = new URL(value2);
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url3.hostname);
+  if (url3.username || url3.password || url3.pathname !== "/" || url3.href.includes("?") || url3.href.includes("#") || value2.includes("\\") || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
+    throw new Error("DROPLIT_SITE_URL requires an HTTPS or HTTP loopback origin without credentials, path, query or fragment");
+  }
+  return url3.origin;
+}
+
 class DroplitError extends Error {
   code;
   status;
@@ -284926,9 +284935,11 @@ function httpFailure(status, details = {}) {
 class DroplitClient {
   config;
   authFetch;
+  siteOrigin;
   wallet;
   constructor(config2) {
     this.config = config2;
+    this.siteOrigin = approvalSiteOrigin(config2.siteUrl);
     if (config2.wallet && config2.authKey)
       throw new Error("Configure Droplit wallet or authKey, not both");
     const url3 = new URL(config2.apiUrl);
@@ -285023,6 +285034,7 @@ class DroplitClient {
       throw new DroplitError("invalid_response", "Sponsor access response did not match the authenticated wallet.");
     }
     access.approval_path = `/droplit/${encodeURIComponent(this.config.faucetName)}?tab=api&request_key=${encodeURIComponent(identity6)}`;
+    access.approval_url = new URL(access.approval_path, this.siteOrigin).href;
     return access;
   }
   async fund(rawtx) {
@@ -285093,7 +285105,7 @@ function registerDroplitTools(server, client, disableBroadcasting = false) {
         ...!access.authorized ? {
           error: "approval_required",
           message: "Ask the sponsor owner to approve this wallet. Copy the approval URL for manual review; do not auto-open or submit approval.",
-          approval_url: `https://droplit.dev${access.approval_path}`
+          approval_url: access.approval_url
         } : {}
       };
       return {
@@ -295163,7 +295175,7 @@ var package_default2 = {
   name: "bsv-mcp",
   module: "dist/index.js",
   type: "module",
-  version: "0.3.2",
+  version: "0.3.3",
   license: "MIT",
   author: "satchmo",
   description: "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",
@@ -298351,12 +298363,25 @@ init_mod2();
 function readDroplitSponsorConfig(env = process.env) {
   const apiUrl = env.DROPLIT_API_URL;
   const faucetName = env.DROPLIT_FAUCET_NAME;
-  if (apiUrl === undefined && faucetName === undefined)
+  const siteUrl = env.DROPLIT_SITE_URL;
+  if (apiUrl === undefined && faucetName === undefined && siteUrl === undefined)
     return;
   if (!apiUrl?.trim() || !faucetName?.trim()) {
     throw new Error("DROPLIT_API_URL and DROPLIT_FAUCET_NAME must both be explicitly configured");
   }
-  return { apiUrl, faucetName };
+  return {
+    apiUrl,
+    faucetName,
+    ...siteUrl === undefined ? {} : { siteUrl: approvalSiteOrigin2(siteUrl) }
+  };
+}
+function approvalSiteOrigin2(value2 = "https://droplit.dev") {
+  const url3 = new URL(value2);
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url3.hostname);
+  if (url3.username || url3.password || url3.pathname !== "/" || url3.href.includes("?") || url3.href.includes("#") || value2.includes("\\") || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
+    throw new Error("DROPLIT_SITE_URL requires an HTTPS or HTTP loopback origin without credentials, path, query or fragment");
+  }
+  return url3.origin;
 }
 
 class DroplitError2 extends Error {
@@ -298408,9 +298433,11 @@ function httpFailure2(status, details = {}) {
 class DroplitClient2 {
   config;
   authFetch;
+  siteOrigin;
   wallet;
   constructor(config2) {
     this.config = config2;
+    this.siteOrigin = approvalSiteOrigin2(config2.siteUrl);
     if (config2.wallet && config2.authKey)
       throw new Error("Configure Droplit wallet or authKey, not both");
     const url3 = new URL(config2.apiUrl);
@@ -298505,6 +298532,7 @@ class DroplitClient2 {
       throw new DroplitError2("invalid_response", "Sponsor access response did not match the authenticated wallet.");
     }
     access.approval_path = `/droplit/${encodeURIComponent(this.config.faucetName)}?tab=api&request_key=${encodeURIComponent(identity6)}`;
+    access.approval_url = new URL(access.approval_path, this.siteOrigin).href;
     return access;
   }
   async fund(rawtx) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bsv-mcp",
 	"module": "dist/index.js",
 	"type": "module",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"license": "MIT",
 	"author": "satchmo",
 	"description": "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",

--- a/tools/wallet/droplit.ts
+++ b/tools/wallet/droplit.ts
@@ -53,7 +53,7 @@ export function registerDroplitTools(
 								error: "approval_required",
 								message:
 									"Ask the sponsor owner to approve this wallet. Copy the approval URL for manual review; do not auto-open or submit approval.",
-								approval_url: `https://droplit.dev${access.approval_path}`,
+								approval_url: access.approval_url,
 							}
 						: {}),
 				};

--- a/utils/droplit.test.ts
+++ b/utils/droplit.test.ts
@@ -87,12 +87,12 @@ test("AuthFetch uses the actual connected wallet and identity, without exposing 
 	expect(legacy.getConfig()).not.toHaveProperty("authKey");
 });
 
-async function tools() {
+async function tools(siteUrl?: string) {
 	const signer = wallet();
 	const server = new McpServer({ name: "droplit-test", version: "1" });
 	registerAllTools(server, {
 		ctx: createContext(signer),
-		droplitClient: new DroplitClient({ ...config, wallet: signer }),
+		droplitClient: new DroplitClient({ ...config, siteUrl, wallet: signer }),
 		enableBsvTools: false,
 		enableOrdinalsTools: false,
 		enableUtilsTools: false,
@@ -311,4 +311,69 @@ test("real SDK 402 payment processor cannot spend through the authentication fac
 	expect(signer.createAction).not.toHaveBeenCalled();
 	expect(signer.signAction).not.toHaveBeenCalled();
 	expect(signer.getPublicKey).toHaveBeenCalled();
+});
+
+for (const siteUrl of [
+	"https://staging.droplit.dev",
+	"http://127.0.0.1:3000",
+	"http://[::1]:3000",
+]) {
+	test(`approval links use configured site ${siteUrl} and ignore server redirects`, async () => {
+		const fetch = spyOn(AuthFetch.prototype, "fetch");
+		const { client, close } = await tools(siteUrl);
+		try {
+			for (const approval_path of [
+				"https://evil.example/x",
+				"//evil.example/x",
+				"\\\\evil.example/x",
+				"/safe/../../wrong?request_key=wrong",
+			]) {
+				fetch.mockResolvedValueOnce(
+					Response.json({
+						...access,
+						approval_path,
+						approval_url: "https://evil.example",
+					}),
+				);
+				const result = await client.callTool({
+					name: "droplit_getAccess",
+					arguments: {},
+				});
+				expect(result.structuredContent).toMatchObject({
+					approval_url: `${siteUrl}/droplit/sponsor?tab=api&request_key=${publicKey}`,
+				});
+			}
+			expect(fetch.mock.calls.every(([, init]) => init?.method === "GET")).toBe(
+				true,
+			);
+		} finally {
+			await close();
+		}
+	});
+}
+
+test("site environment is forwarded and unsafe site configuration fails before wallet access", () => {
+	expect(
+		readDroplitSponsorConfig({
+			DROPLIT_API_URL: config.apiUrl,
+			DROPLIT_FAUCET_NAME: config.faucetName,
+			DROPLIT_SITE_URL: "https://staging.droplit.dev/",
+		}),
+	).toEqual({ ...config, siteUrl: "https://staging.droplit.dev" });
+	for (const siteUrl of [
+		"",
+		"not a URL",
+		"http://evil.example",
+		"https://user:pass@droplit.dev",
+		"https://droplit.dev/path",
+		"https://droplit.dev?",
+		"https://droplit.dev#",
+		"https://droplit.dev\\evil",
+	]) {
+		const signer = wallet();
+		expect(
+			() => new DroplitClient({ ...config, siteUrl, wallet: signer }),
+		).toThrow();
+		expect(signer.getPublicKey).not.toHaveBeenCalled();
+	}
 });

--- a/utils/droplit.ts
+++ b/utils/droplit.ts
@@ -20,6 +20,8 @@ import {
  */
 
 export interface DroplitConfig {
+	/** Human approval site origin; defaults to https://droplit.dev. */
+	siteUrl?: string;
 	apiUrl: string;
 	faucetName: string;
 	/** Identity for the BRC-103/104 handshake. Unauthenticated without it. */
@@ -36,20 +38,46 @@ export interface FaucetAccess {
 	quotas: Array<Record<string, unknown>>;
 	unrestricted_kinds: string[];
 	approval_path: string;
+	approval_url: string;
 }
 
 export function readDroplitSponsorConfig(
 	env: Record<string, string | undefined> = process.env,
-): Pick<DroplitConfig, "apiUrl" | "faucetName"> | undefined {
+): Pick<DroplitConfig, "apiUrl" | "faucetName" | "siteUrl"> | undefined {
 	const apiUrl = env.DROPLIT_API_URL;
 	const faucetName = env.DROPLIT_FAUCET_NAME;
-	if (apiUrl === undefined && faucetName === undefined) return undefined;
+	const siteUrl = env.DROPLIT_SITE_URL;
+	if (apiUrl === undefined && faucetName === undefined && siteUrl === undefined)
+		return undefined;
 	if (!apiUrl?.trim() || !faucetName?.trim()) {
 		throw new Error(
 			"DROPLIT_API_URL and DROPLIT_FAUCET_NAME must both be explicitly configured",
 		);
 	}
-	return { apiUrl, faucetName };
+	return {
+		apiUrl,
+		faucetName,
+		...(siteUrl === undefined ? {} : { siteUrl: approvalSiteOrigin(siteUrl) }),
+	};
+}
+
+function approvalSiteOrigin(value = "https://droplit.dev"): string {
+	const url = new URL(value);
+	const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+	if (
+		url.username ||
+		url.password ||
+		url.pathname !== "/" ||
+		url.href.includes("?") ||
+		url.href.includes("#") ||
+		value.includes("\\") ||
+		!(url.protocol === "https:" || (url.protocol === "http:" && loopback))
+	) {
+		throw new Error(
+			"DROPLIT_SITE_URL requires an HTTPS or HTTP loopback origin without credentials, path, query or fragment",
+		);
+	}
+	return url.origin;
 }
 
 export class DroplitError extends Error {
@@ -130,9 +158,11 @@ export class DroplitClient {
 	 * fresh instance per call would repeat the handshake every request.
 	 */
 	private readonly authFetch?: AuthFetch;
+	private readonly siteOrigin: string;
 	private readonly wallet?: WalletInterface | ProtoWallet;
 
 	constructor(private config: DroplitConfig) {
+		this.siteOrigin = approvalSiteOrigin(config.siteUrl);
 		if (config.wallet && config.authKey)
 			throw new Error("Configure Droplit wallet or authKey, not both");
 		const url = new URL(config.apiUrl);
@@ -303,6 +333,7 @@ export class DroplitClient {
 		// Build the convenience path from our configuration and signer identity,
 		// never from an arbitrary server-supplied redirect.
 		access.approval_path = `/droplit/${encodeURIComponent(this.config.faucetName)}?tab=api&request_key=${encodeURIComponent(identity)}`;
+		access.approval_url = new URL(access.approval_path, this.siteOrigin).href;
 		return access;
 	}
 


### PR DESCRIPTION
Sponsor access requests previously always sent owners to production, even when the MCP server used a staging sponsor API. `DROPLIT_SITE_URL` now selects the human approval origin, with the existing production default.

The shared client validates the origin and constructs links from its configured sponsor and authenticated wallet key, ignoring server-supplied redirect fields. Read-only access and payment guards are unchanged.

Validation: 109 tests/370 assertions, bundle build, Biome, and independent Ponytail/security review. Includes staging and loopback origins, invalid configuration, and malicious server redirect inputs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791291616&installation_model_id=435537&pr_number=9&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F9&signature=3d93100064e132542546e9f159b64bcae9834c176d9f684a267b3777a0363830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->