### PR TITLE
Add unsigned public sponsor discovery (0.3.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "bsv-mcp",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "Bitcoin SV MCP server with interactive dashboard — Explorer, Wallet, and Ordinals tabs via MCP Apps. Tools for price lookup, transaction decoding, address lookup, wallet management, NFT marketplace, and identity.",
 	"author": {
 		"name": "rohenaz",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # BSV MCP Server Changelog
 
+## [0.3.4] - 2026-09-06
+
+### Added
+- Discover owner-listed Droplit sponsors without a wallet or preselected faucet.
+- Validate public responses and pagination; discovery never authorizes access or payment.
+
+
 ## [0.3.3] - 2026-09-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -888,11 +888,21 @@ DROPLIT_FAUCET_NAME=your-sponsor-slug
 DROPLIT_SITE_URL=https://droplit.dev
 ```
 
-Set both sponsor values explicitly. The URL includes the server's configured
+Set both sponsor values explicitly for wallet operations. The URL includes the server's configured
 base path. Leave `USE_DROPLIT_API` unset: these sponsor tools appear alongside
 normal wallet tools and use the same connected signer identity. Existing local
 BRC-100 wallet contexts also support this sponsor pair. `1sat serve` exposes a
 wallet stack service; it is not itself a BRC-100 signer RPC endpoint.
+
+For public sponsor discovery, set only `DROPLIT_API_URL` and call
+`droplit_discover` with optional `limit` (1–50, default 20) and `after`
+(the previous `next_cursor`). This unsigned read needs no selected sponsor or
+wallet and returns only names, slugs, and `approval_required: true`. It neither
+creates a wallet nor grants sponsor access. Normal MCP startup retains its
+existing wallet initialization behavior; this tool itself makes no wallet calls.
+An empty catalog means no owners have opted in. Select a listed slug, configure
+`DROPLIT_FAUCET_NAME`, and use the existing wallet access/owner approval flow.
+Listing does not promise funding or quota availability.
 
 Call `droplit_getAccess` to inspect your own authorization and quotas. An
 `approval_required` response includes a link to `DROPLIT_SITE_URL` (default

--- a/dist/index.js
+++ b/dist/index.js
@@ -256042,7 +256042,7 @@ var package_default = {
   name: "bsv-mcp",
   module: "dist/index.js",
   type: "module",
-  version: "0.3.3",
+  version: "0.3.4",
   license: "MIT",
   author: "satchmo",
   description: "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",
@@ -284877,6 +284877,14 @@ function registerUtilsTools(server) {
 
 // utils/droplit.ts
 init_mod2();
+function droplitApiBaseUrl(apiUrl) {
+  const url3 = new URL(apiUrl);
+  const loopback = url3.hostname === "localhost" || url3.hostname === "127.0.0.1" || url3.hostname === "[::1]";
+  if (url3.username || url3.password || url3.search || url3.hash || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
+    throw new Error("Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment");
+  }
+  return url3.href.replace(/\/$/, "");
+}
 function approvalSiteOrigin(value2 = "https://droplit.dev") {
   const url3 = new URL(value2);
   const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url3.hostname);
@@ -284942,11 +284950,7 @@ class DroplitClient {
     this.siteOrigin = approvalSiteOrigin(config2.siteUrl);
     if (config2.wallet && config2.authKey)
       throw new Error("Configure Droplit wallet or authKey, not both");
-    const url3 = new URL(config2.apiUrl);
-    const loopback = url3.hostname === "localhost" || url3.hostname === "127.0.0.1" || url3.hostname === "[::1]";
-    if (url3.username || url3.password || url3.search || url3.hash || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
-      throw new Error("Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment");
-    }
+    droplitApiBaseUrl(config2.apiUrl);
     if (!config2.faucetName.trim())
       throw new Error("Droplit faucet name is required");
     this.wallet = config2.wallet ?? (config2.authKey ? new ProtoWallet_default(config2.authKey) : undefined);
@@ -285070,6 +285074,74 @@ class DroplitClient {
   async authenticatedFetch(path3, init) {
     return this.authed(path3, init);
   }
+}
+var publicSponsorsSchema = exports_external.object({
+  sponsors: exports_external.array(exports_external.object({
+    name: exports_external.string(),
+    slug: exports_external.string().min(1),
+    approval_required: exports_external.literal(true)
+  })).max(50),
+  next_cursor: exports_external.string().min(1).nullable()
+});
+async function discoverDroplitSponsors(apiUrl, options = {}) {
+  const limit = options.limit ?? 20;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 50)
+    throw new Error("limit must be an integer from 1 to 50");
+  const url3 = new URL(`${droplitApiBaseUrl(apiUrl)}/sponsors`);
+  url3.searchParams.set("limit", String(limit));
+  if (options.after !== undefined)
+    url3.searchParams.set("after", options.after);
+  let response;
+  try {
+    response = await fetch(url3, {
+      method: "GET",
+      redirect: "error",
+      credentials: "omit",
+      signal: AbortSignal.timeout(15000)
+    });
+  } catch {
+    throw new DroplitError("request_failed", "Could not read public sponsors. Check the configured API origin.");
+  }
+  if (!response.ok)
+    throw new DroplitError("request_failed", "Could not read public sponsors.", response.status);
+  try {
+    return publicSponsorsSchema.parse(await response.json());
+  } catch {
+    throw new DroplitError("invalid_response", "Public sponsor response was invalid.");
+  }
+}
+
+// tools/wallet/droplitDiscovery.ts
+function registerDroplitDiscoveryTool(server, apiUrl) {
+  const baseUrl = droplitApiBaseUrl(apiUrl);
+  server.registerTool("droplit_discover", {
+    description: "List publicly opted-in sponsors. No wallet or sponsor selection is required. Listing grants no access or funding; choose a slug, then request the sponsor owner's approval separately.",
+    inputSchema: {
+      limit: exports_external.number().int().min(1).max(50).optional(),
+      after: exports_external.string().optional()
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    }
+  }, async (options) => {
+    try {
+      const data = await discoverDroplitSponsors(baseUrl, options);
+      return { ...createSuccessResponse(data), structuredContent: data };
+    } catch (error52) {
+      const data = {
+        error: error52 instanceof DroplitError ? error52.code : "invalid_request",
+        message: error52 instanceof DroplitError ? error52.message : "Invalid sponsor discovery request."
+      };
+      return {
+        ...createSuccessResponse(data),
+        structuredContent: data,
+        isError: true
+      };
+    }
+  });
 }
 
 // tools/wallet/droplit.ts
@@ -295175,7 +295247,7 @@ var package_default2 = {
   name: "bsv-mcp",
   module: "dist/index.js",
   type: "module",
-  version: "0.3.3",
+  version: "0.3.4",
   license: "MIT",
   author: "satchmo",
   description: "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",
@@ -297908,6 +297980,9 @@ function registerAllTools(server, config2 = {}) {
   }
   if (enableUtilsTools) {
     registerUtilsTools(server);
+    const apiUrl = config2.droplitApiUrl ?? process.env.DROPLIT_API_URL ?? config2.droplitClient?.getConfig().apiUrl;
+    if (apiUrl)
+      registerDroplitDiscoveryTool(server, apiUrl);
   }
   if (enableA2bTools) {
     registerA2bDiscoverTool(server);
@@ -298366,6 +298441,12 @@ function readDroplitSponsorConfig(env = process.env) {
   const siteUrl = env.DROPLIT_SITE_URL;
   if (apiUrl === undefined && faucetName === undefined && siteUrl === undefined)
     return;
+  if (apiUrl?.trim() && faucetName === undefined) {
+    droplitApiBaseUrl2(apiUrl);
+    if (siteUrl !== undefined)
+      approvalSiteOrigin2(siteUrl);
+    return;
+  }
   if (!apiUrl?.trim() || !faucetName?.trim()) {
     throw new Error("DROPLIT_API_URL and DROPLIT_FAUCET_NAME must both be explicitly configured");
   }
@@ -298374,6 +298455,14 @@ function readDroplitSponsorConfig(env = process.env) {
     faucetName,
     ...siteUrl === undefined ? {} : { siteUrl: approvalSiteOrigin2(siteUrl) }
   };
+}
+function droplitApiBaseUrl2(apiUrl) {
+  const url3 = new URL(apiUrl);
+  const loopback = url3.hostname === "localhost" || url3.hostname === "127.0.0.1" || url3.hostname === "[::1]";
+  if (url3.username || url3.password || url3.search || url3.hash || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
+    throw new Error("Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment");
+  }
+  return url3.href.replace(/\/$/, "");
 }
 function approvalSiteOrigin2(value2 = "https://droplit.dev") {
   const url3 = new URL(value2);
@@ -298440,11 +298529,7 @@ class DroplitClient2 {
     this.siteOrigin = approvalSiteOrigin2(config2.siteUrl);
     if (config2.wallet && config2.authKey)
       throw new Error("Configure Droplit wallet or authKey, not both");
-    const url3 = new URL(config2.apiUrl);
-    const loopback = url3.hostname === "localhost" || url3.hostname === "127.0.0.1" || url3.hostname === "[::1]";
-    if (url3.username || url3.password || url3.search || url3.hash || !(url3.protocol === "https:" || url3.protocol === "http:" && loopback)) {
-      throw new Error("Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment");
-    }
+    droplitApiBaseUrl2(config2.apiUrl);
     if (!config2.faucetName.trim())
       throw new Error("Droplit faucet name is required");
     this.wallet = config2.wallet ?? (config2.authKey ? new ProtoWallet_default(config2.authKey) : undefined);
@@ -298569,6 +298654,14 @@ class DroplitClient2 {
     return this.authed(path5, init);
   }
 }
+var publicSponsorsSchema2 = exports_external.object({
+  sponsors: exports_external.array(exports_external.object({
+    name: exports_external.string(),
+    slug: exports_external.string().min(1),
+    approval_required: exports_external.literal(true)
+  })).max(50),
+  next_cursor: exports_external.string().min(1).nullable()
+});
 
 // utils/externalWalletConfig.ts
 function readExternalWalletConfig(env = process.env) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bsv-mcp",
 	"module": "dist/index.js",
 	"type": "module",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"license": "MIT",
 	"author": "satchmo",
 	"description": "A collection of Bitcoin SV (BSV) tools for the Model Context Protocol (MCP) framework",

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -10,6 +10,7 @@ import { registerBsvTools } from "./bsv";
 import { registerMneeTools } from "./mnee";
 import { registerOrdinalsTools } from "./ordinals";
 import { registerUtilsTools } from "./utils";
+import { registerDroplitDiscoveryTool } from "./wallet/droplitDiscovery";
 import { registerDroplitTools } from "./wallet/droplit";
 import { registerWalletGetBalanceDroplitTool } from "./wallet/getBalanceDroplit";
 import type { IntegratedWallet } from "./wallet/integratedWallet";
@@ -48,6 +49,7 @@ export interface ToolsConfig {
 	ctx?: OneSatContext;
 	services?: OneSatServices;
 	droplitClient?: DroplitClient;
+	droplitApiUrl?: string;
 }
 
 /**
@@ -94,6 +96,11 @@ export function registerAllTools(
 	// Register utility tools
 	if (enableUtilsTools) {
 		registerUtilsTools(server);
+		const apiUrl =
+			config.droplitApiUrl ??
+			process.env.DROPLIT_API_URL ??
+			config.droplitClient?.getConfig().apiUrl;
+		if (apiUrl) registerDroplitDiscoveryTool(server, apiUrl);
 	}
 
 	// Register agent-to-blockchain tools

--- a/tools/wallet/droplitDiscovery.ts
+++ b/tools/wallet/droplitDiscovery.ts
@@ -1,0 +1,51 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+	discoverDroplitSponsors,
+	droplitApiBaseUrl,
+	DroplitError,
+} from "../../utils/droplit";
+import { createSuccessResponse } from "../utils/errorHandler";
+
+export function registerDroplitDiscoveryTool(
+	server: McpServer,
+	apiUrl: string,
+) {
+	const baseUrl = droplitApiBaseUrl(apiUrl);
+	server.registerTool(
+		"droplit_discover",
+		{
+			description:
+				"List publicly opted-in sponsors. No wallet or sponsor selection is required. Listing grants no access or funding; choose a slug, then request the sponsor owner's approval separately.",
+			inputSchema: {
+				limit: z.number().int().min(1).max(50).optional(),
+				after: z.string().optional(),
+			},
+			annotations: {
+				readOnlyHint: true,
+				destructiveHint: false,
+				idempotentHint: true,
+				openWorldHint: true,
+			},
+		},
+		async (options) => {
+			try {
+				const data = await discoverDroplitSponsors(baseUrl, options);
+				return { ...createSuccessResponse(data), structuredContent: data };
+			} catch (error) {
+				const data = {
+					error: error instanceof DroplitError ? error.code : "invalid_request",
+					message:
+						error instanceof DroplitError
+							? error.message
+							: "Invalid sponsor discovery request.",
+				};
+				return {
+					...createSuccessResponse(data),
+					structuredContent: data,
+					isError: true,
+				};
+			}
+		},
+	);
+}

--- a/utils/droplit-discovery.test.ts
+++ b/utils/droplit-discovery.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import { AuthFetch } from "@bsv/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerDroplitDiscoveryTool } from "../tools/wallet/droplitDiscovery";
+import { discoverDroplitSponsors, readDroplitSponsorConfig } from "./droplit";
+const api = "https://api.example.test/prefix";
+const body = {
+	sponsors: [{ name: "Example", slug: "example", approval_required: true }],
+	next_cursor: null,
+};
+afterEach(() => mock.restore());
+
+test("discovery is unsigned, strips unexpected private fields, and encodes pagination", async () => {
+	const signed = spyOn(AuthFetch.prototype, "fetch").mockImplementation(() => {
+		throw new Error("must not authenticate");
+	});
+	const fetch = spyOn(globalThis, "fetch").mockResolvedValue(
+		Response.json({
+			...body,
+			owner_key: "private",
+			sponsors: [{ ...body.sponsors[0], owner_key: "private" }],
+		}),
+	);
+	expect(readDroplitSponsorConfig({ DROPLIT_API_URL: api })).toBeUndefined();
+	expect(
+		await discoverDroplitSponsors(api, { limit: 2, after: "a&injected=true" }),
+	).toEqual(body);
+	const [url, options] = fetch.mock.calls[0];
+	expect(String(url)).toBe(`${api}/sponsors?limit=2&after=a%26injected%3Dtrue`);
+	expect(options).toMatchObject({
+		method: "GET",
+		redirect: "error",
+		credentials: "omit",
+	});
+	expect(options?.headers).toBeUndefined();
+	expect(signed).not.toHaveBeenCalled();
+});
+
+test("invalid URL and limits fail before fetch; HTTP and invalid bodies are redacted", async () => {
+	const fetch = spyOn(globalThis, "fetch");
+	for (const invalid of [
+		"http://evil.test",
+		"https://user:password@api.test",
+		"https://api.test?x=1",
+	]) {
+		await expect(discoverDroplitSponsors(invalid)).rejects.toThrow();
+	}
+	for (const limit of [0, 51, 1.5])
+		await expect(discoverDroplitSponsors(api, { limit })).rejects.toThrow();
+	expect(fetch).not.toHaveBeenCalled();
+	fetch.mockResolvedValueOnce(new Response("secret", { status: 402 }));
+	await expect(discoverDroplitSponsors(api)).rejects.toMatchObject({
+		code: "request_failed",
+		status: 402,
+	});
+	fetch.mockResolvedValueOnce(
+		Response.json({
+			...body,
+			sponsors: [{ ...body.sponsors[0], approval_required: false }],
+		}),
+	);
+	await expect(discoverDroplitSponsors(api)).rejects.toMatchObject({
+		code: "invalid_response",
+	});
+	fetch.mockRejectedValueOnce(new Error("credential leak"));
+	await expect(discoverDroplitSponsors(api)).rejects.toThrow(
+		"Could not read public sponsors. Check the configured API origin.",
+	);
+});
+
+test("MCP discovery requires no wallet or selected sponsor and preserves empty catalog", async () => {
+	const fetch = spyOn(globalThis, "fetch").mockResolvedValue(
+		Response.json({ sponsors: [], next_cursor: null }),
+	);
+	const server = new McpServer({ name: "discovery", version: "1" });
+	registerDroplitDiscoveryTool(server, api);
+	const client = new Client({ name: "buyer", version: "1" });
+	const [a, b] = InMemoryTransport.createLinkedPair();
+	await server.connect(a);
+	await client.connect(b);
+	try {
+		const listed = await client.listTools();
+		expect(
+			listed.tools.find((t) => t.name === "droplit_discover")?.annotations
+				?.readOnlyHint,
+		).toBe(true);
+		const result = await client.callTool({
+			name: "droplit_discover",
+			arguments: {},
+		});
+		expect(result.structuredContent).toEqual({
+			sponsors: [],
+			next_cursor: null,
+		});
+		expect(String(fetch.mock.calls[0][0])).toBe(`${api}/sponsors?limit=20`);
+		const invalid = await client.callTool({
+			name: "droplit_discover",
+			arguments: { limit: 51 },
+		});
+		expect(invalid.isError).toBe(true);
+		expect(fetch).toHaveBeenCalledTimes(1);
+	} finally {
+		await client.close();
+		await server.close();
+	}
+});

--- a/utils/droplit.test.ts
+++ b/utils/droplit.test.ts
@@ -34,11 +34,11 @@ function wallet() {
 }
 afterEach(() => mock.restore());
 
-test("sponsor configuration requires an explicit pair", () => {
+test("sponsor operations require a pair while API-only config permits discovery", () => {
 	expect(readDroplitSponsorConfig({})).toBeUndefined();
-	expect(() =>
+	expect(
 		readDroplitSponsorConfig({ DROPLIT_API_URL: config.apiUrl }),
-	).toThrow("both");
+	).toBeUndefined();
 	expect(() =>
 		readDroplitSponsorConfig({ DROPLIT_FAUCET_NAME: config.faucetName }),
 	).toThrow("both");

--- a/utils/droplit.ts
+++ b/utils/droplit.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
 	AuthFetch,
 	type PrivateKey,
@@ -49,6 +50,11 @@ export function readDroplitSponsorConfig(
 	const siteUrl = env.DROPLIT_SITE_URL;
 	if (apiUrl === undefined && faucetName === undefined && siteUrl === undefined)
 		return undefined;
+	if (apiUrl?.trim() && faucetName === undefined) {
+		droplitApiBaseUrl(apiUrl);
+		if (siteUrl !== undefined) approvalSiteOrigin(siteUrl);
+		return undefined; // API-only configuration enables unsigned discovery.
+	}
 	if (!apiUrl?.trim() || !faucetName?.trim()) {
 		throw new Error(
 			"DROPLIT_API_URL and DROPLIT_FAUCET_NAME must both be explicitly configured",
@@ -59,6 +65,26 @@ export function readDroplitSponsorConfig(
 		faucetName,
 		...(siteUrl === undefined ? {} : { siteUrl: approvalSiteOrigin(siteUrl) }),
 	};
+}
+
+export function droplitApiBaseUrl(apiUrl: string): string {
+	const url = new URL(apiUrl);
+	const loopback =
+		url.hostname === "localhost" ||
+		url.hostname === "127.0.0.1" ||
+		url.hostname === "[::1]";
+	if (
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash ||
+		!(url.protocol === "https:" || (url.protocol === "http:" && loopback))
+	) {
+		throw new Error(
+			"Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment",
+		);
+	}
+	return url.href.replace(/\/$/, "");
 }
 
 function approvalSiteOrigin(value = "https://droplit.dev"): string {
@@ -165,22 +191,7 @@ export class DroplitClient {
 		this.siteOrigin = approvalSiteOrigin(config.siteUrl);
 		if (config.wallet && config.authKey)
 			throw new Error("Configure Droplit wallet or authKey, not both");
-		const url = new URL(config.apiUrl);
-		const loopback =
-			url.hostname === "localhost" ||
-			url.hostname === "127.0.0.1" ||
-			url.hostname === "[::1]";
-		if (
-			url.username ||
-			url.password ||
-			url.search ||
-			url.hash ||
-			!(url.protocol === "https:" || (url.protocol === "http:" && loopback))
-		) {
-			throw new Error(
-				"Droplit API requires HTTPS or HTTP loopback without credentials, query or fragment",
-			);
-		}
+		droplitApiBaseUrl(config.apiUrl);
 		if (!config.faucetName.trim())
 			throw new Error("Droplit faucet name is required");
 		this.wallet =
@@ -384,5 +395,59 @@ export class DroplitClient {
 		init: { method: string; body?: unknown },
 	): Promise<Response> {
 		return this.authed(path, init);
+	}
+}
+
+const publicSponsorsSchema = z.object({
+	sponsors: z
+		.array(
+			z.object({
+				name: z.string(),
+				slug: z.string().min(1),
+				approval_required: z.literal(true),
+			}),
+		)
+		.max(50),
+	next_cursor: z.string().min(1).nullable(),
+});
+
+/** Public catalog only: never constructs AuthFetch or touches a wallet. */
+export async function discoverDroplitSponsors(
+	apiUrl: string,
+	options: { limit?: number; after?: string } = {},
+) {
+	const limit = options.limit ?? 20;
+	if (!Number.isInteger(limit) || limit < 1 || limit > 50)
+		throw new Error("limit must be an integer from 1 to 50");
+	const url = new URL(`${droplitApiBaseUrl(apiUrl)}/sponsors`);
+	url.searchParams.set("limit", String(limit));
+	if (options.after !== undefined) url.searchParams.set("after", options.after);
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "GET",
+			redirect: "error",
+			credentials: "omit",
+			signal: AbortSignal.timeout(15000),
+		});
+	} catch {
+		throw new DroplitError(
+			"request_failed",
+			"Could not read public sponsors. Check the configured API origin.",
+		);
+	}
+	if (!response.ok)
+		throw new DroplitError(
+			"request_failed",
+			"Could not read public sponsors.",
+			response.status,
+		);
+	try {
+		return publicSponsorsSchema.parse(await response.json());
+	} catch {
+		throw new DroplitError(
+			"invalid_response",
+			"Public sponsor response was invalid.",
+		);
 	}
 }


### PR DESCRIPTION
Adds unsigned `droplit_discover` so agents can find owner-listed sponsors without first configuring a wallet or faucet. The tool validates pagination and projects only public fields; discovering a sponsor grants no wallet access or payment authority.

Validation: 112 tests / 391 assertions, build, independent review, and real unsigned CLI/MCP discovery against an isolated backend with signed owner opt-in/out. No broadcasts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791293634&installation_model_id=435537&pr_number=10&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F10&signature=a3c10f30a09ffbd0de4e91c623a1a38adc802a6d9422d25d86580f9834e09c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->