### PR TITLE
Add a landing page, fix the Tailwind build, and standardize on shadcn/ui tokens

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 
-// The /auth route is no longer used. The onboarding flow lives at /.
+// The /auth route is no longer used. The onboarding flow lives at /connect.
 export default function AuthPage() {
-	redirect("/");
+	redirect("/connect");
 }

--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { BackupSection } from "@/components/onboarding/BackupSection";
+import { ConfigTabs } from "@/components/onboarding/ConfigTabs";
+import { KeySetup } from "@/components/onboarding/KeySetup";
+import { useKeyState } from "@/components/onboarding/use-key-state";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+
+export default function OnboardingPage() {
+	const {
+		state,
+		dispatch,
+		fileInputRef,
+		generateNewKey,
+		handleFileSelect,
+		decryptBackup,
+		authenticate,
+		downloadBackup,
+		copyToClipboard,
+	} = useKeyState();
+
+	const isAuthenticated = !!state.sessionToken;
+	const stepOffset = state.source === "new" ? 1 : 0;
+
+	return (
+		<div className="min-h-screen flex items-center justify-center p-4">
+			<a
+				href="/"
+				className="fixed left-4 top-4 text-sm text-muted-foreground hover:text-foreground"
+			>
+				← Home
+			</a>
+			<div className="w-full max-w-lg space-y-6">
+				{/* Header */}
+				<div className="text-center space-y-1">
+					<h1 className="text-3xl font-bold tracking-tight">BSV MCP</h1>
+					<p className="text-muted-foreground text-sm">
+						Model Context Protocol for Bitcoin SV
+					</p>
+					<p className="text-xs text-muted-foreground/60">
+						MCP 2025-03-26 Specification
+					</p>
+				</div>
+
+				{/* Auth card */}
+				<Card>
+					<CardHeader>
+						<CardTitle>Authenticate</CardTitle>
+						<CardDescription>
+							Generate a new Bitcoin key or import an existing backup to connect
+							to the hosted MCP server.
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<KeySetup
+							state={state}
+							dispatch={dispatch}
+							fileInputRef={fileInputRef}
+							onGenerate={generateNewKey}
+							onFileSelect={handleFileSelect}
+							onDecrypt={decryptBackup}
+							onAuthenticate={authenticate}
+						/>
+					</CardContent>
+				</Card>
+
+				{/* Post-auth steps */}
+				{isAuthenticated && (
+					<>
+						{/* Step 1: Backup (new keys only) */}
+						{state.source === "new" && (
+							<Card>
+								<CardHeader>
+									<CardTitle>Step 1: Download Your Backup</CardTitle>
+									<CardDescription>
+										Save your private key before proceeding. You cannot recover
+										it without this file.
+									</CardDescription>
+								</CardHeader>
+								<CardContent>
+									<BackupSection onDownload={downloadBackup} />
+								</CardContent>
+							</Card>
+						)}
+
+						{/* Step 2 (or 1 for imported keys): Config */}
+						<Card>
+							<CardHeader>
+								<CardTitle>
+									Step {stepOffset + 1}: Installation &amp; Configuration
+								</CardTitle>
+								<CardDescription>
+									Choose your platform and copy the configuration snippet.
+								</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<ConfigTabs
+									mcpUrl={state.mcpUrl}
+									sessionToken={state.sessionToken}
+									copied={state.copied}
+									onCopy={copyToClipboard}
+								/>
+							</CardContent>
+						</Card>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
 import { BackupSection } from "@/components/onboarding/BackupSection";
 import { ConfigTabs } from "@/components/onboarding/ConfigTabs";
 import { KeySetup } from "@/components/onboarding/KeySetup";
 import { useKeyState } from "@/components/onboarding/use-key-state";
+import { Button } from "@/components/ui/button";
 import {
 	Card,
 	CardContent,
@@ -30,12 +33,17 @@ export default function OnboardingPage() {
 
 	return (
 		<div className="min-h-screen flex items-center justify-center p-4">
-			<a
-				href="/"
-				className="fixed left-4 top-4 text-sm text-muted-foreground hover:text-foreground"
+			<Button
+				variant="ghost"
+				size="sm"
+				asChild
+				className="fixed left-4 top-4 text-muted-foreground"
 			>
-				← Home
-			</a>
+				<Link href="/">
+					<ArrowLeft />
+					Home
+				</Link>
+			</Button>
 			<div className="w-full max-w-lg space-y-6">
 				{/* Header */}
 				<div className="text-center space-y-1">

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,47 +4,85 @@
 @layer base {
 	:root {
 		--background: 0 0% 100%;
-		--foreground: 222.2 84% 4.9%;
+		--foreground: 240 10% 3.9%;
 		--card: 0 0% 100%;
-		--card-foreground: 222.2 84% 4.9%;
+		--card-foreground: 240 10% 3.9%;
 		--popover: 0 0% 100%;
-		--popover-foreground: 222.2 84% 4.9%;
-		--primary: 222.2 47.4% 11.2%;
-		--primary-foreground: 210 40% 98%;
-		--secondary: 210 40% 96.1%;
-		--secondary-foreground: 222.2 47.4% 11.2%;
-		--muted: 210 40% 96.1%;
-		--muted-foreground: 215.4 16.3% 46.9%;
-		--accent: 210 40% 96.1%;
-		--accent-foreground: 222.2 47.4% 11.2%;
+		--popover-foreground: 240 10% 3.9%;
+		--primary: 38 92% 45%;
+		--primary-foreground: 26 83% 8%;
+		--secondary: 240 4.8% 95.9%;
+		--secondary-foreground: 240 5.9% 10%;
+		--muted: 240 4.8% 95.9%;
+		--muted-foreground: 240 3.8% 46.1%;
+		--accent: 240 4.8% 95.9%;
+		--accent-foreground: 240 5.9% 10%;
 		--destructive: 0 84.2% 60.2%;
-		--destructive-foreground: 210 40% 98%;
-		--border: 214.3 31.8% 91.4%;
-		--input: 214.3 31.8% 91.4%;
-		--ring: 222.2 84% 4.9%;
-		--radius: 0.5rem;
+		--destructive-foreground: 0 0% 98%;
+		--success: 142 71% 40%;
+		--success-foreground: 0 0% 100%;
+		--warning: 38 92% 45%;
+		--warning-foreground: 26 83% 8%;
+		--border: 240 5.9% 90%;
+		--input: 240 5.9% 90%;
+		--ring: 38 92% 45%;
+		--radius: 0.65rem;
+
+		--chart-1: 38 92% 50%;
+		--chart-2: 173 58% 39%;
+		--chart-3: 197 37% 24%;
+		--chart-4: 43 74% 66%;
+		--chart-5: 27 87% 67%;
+
+		--sidebar: 0 0% 98%;
+		--sidebar-foreground: 240 5.3% 26.1%;
+		--sidebar-primary: 240 5.9% 10%;
+		--sidebar-primary-foreground: 0 0% 98%;
+		--sidebar-accent: 240 4.8% 95.9%;
+		--sidebar-accent-foreground: 240 5.9% 10%;
+		--sidebar-border: 220 13% 91%;
+		--sidebar-ring: 38 92% 45%;
 	}
 
 	.dark {
-		--background: 222.2 84% 4.9%;
+		--background: 222 47% 5%;
 		--foreground: 210 40% 98%;
-		--card: 222.2 47.4% 7%;
+		--card: 222 44% 7.5%;
 		--card-foreground: 210 40% 98%;
-		--popover: 222.2 47.4% 7%;
+		--popover: 222 44% 7.5%;
 		--popover-foreground: 210 40% 98%;
-		--primary: 210 40% 98%;
-		--primary-foreground: 222.2 47.4% 11.2%;
-		--secondary: 217.2 32.6% 17.5%;
+		--primary: 38 92% 50%;
+		--primary-foreground: 26 83% 8%;
+		--secondary: 217 33% 15%;
 		--secondary-foreground: 210 40% 98%;
-		--muted: 217.2 32.6% 17.5%;
-		--muted-foreground: 215 20.2% 65.1%;
-		--accent: 217.2 32.6% 17.5%;
+		--muted: 217 33% 15%;
+		--muted-foreground: 215 20% 65%;
+		--accent: 217 33% 17%;
 		--accent-foreground: 210 40% 98%;
-		--destructive: 0 62.8% 30.6%;
-		--destructive-foreground: 210 40% 98%;
-		--border: 217.2 32.6% 17.5%;
-		--input: 217.2 32.6% 17.5%;
-		--ring: 212.7 26.8% 83.9%;
+		--destructive: 0 72% 51%;
+		--destructive-foreground: 0 0% 98%;
+		--success: 142 69% 45%;
+		--success-foreground: 144 80% 6%;
+		--warning: 38 92% 50%;
+		--warning-foreground: 26 83% 8%;
+		--border: 217 33% 17%;
+		--input: 217 33% 17%;
+		--ring: 38 92% 50%;
+
+		--chart-1: 38 92% 50%;
+		--chart-2: 160 60% 45%;
+		--chart-3: 0 72% 58%;
+		--chart-4: 280 65% 65%;
+		--chart-5: 200 80% 55%;
+
+		--sidebar: 222 44% 7.5%;
+		--sidebar-foreground: 210 40% 98%;
+		--sidebar-primary: 38 92% 50%;
+		--sidebar-primary-foreground: 26 83% 8%;
+		--sidebar-accent: 217 33% 17%;
+		--sidebar-accent-foreground: 210 40% 98%;
+		--sidebar-border: 217 33% 17%;
+		--sidebar-ring: 38 92% 50%;
 	}
 
 	* {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,9 +14,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-	title: "BSV MCP — Hosted Service",
+	title: "BSV MCP — Bitcoin SV tools for AI agents",
 	description:
-		"Bitcoin SV Model Context Protocol — authenticate and generate your MCP configuration.",
+		"An open source Model Context Protocol server that gives Claude, Cursor, and any MCP client a Bitcoin SV wallet: send BSV, inscribe ordinals, manage identity, and read the chain.",
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,110 +1,504 @@
-"use client";
-
-import { BackupSection } from "@/components/onboarding/BackupSection";
-import { ConfigTabs } from "@/components/onboarding/ConfigTabs";
-import { KeySetup } from "@/components/onboarding/KeySetup";
-import { useKeyState } from "@/components/onboarding/use-key-state";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
+	ArrowRight,
+	Bitcoin,
+	Blocks,
+	Cloud,
+	Fingerprint,
+	Github,
+	Image as ImageIcon,
+	KeyRound,
+	MessageSquare,
+	Plug,
+	Search,
+	Server,
+	ShieldCheck,
+	Terminal,
+	Wallet,
+	Wrench,
+} from "lucide-react";
+import Link from "next/link";
+import { CopyCommand } from "@/components/landing/CopyCommand";
 
-export default function OnboardingPage() {
-	const {
-		state,
-		dispatch,
-		fileInputRef,
-		generateNewKey,
-		handleFileSelect,
-		decryptBackup,
-		authenticate,
-		downloadBackup,
-		copyToClipboard,
-	} = useKeyState();
+const GITHUB_URL = "https://github.com/b-open-io/bsv-mcp";
+const NPM_URL = "https://www.npmjs.com/package/bsv-mcp";
 
-	const isAuthenticated = !!state.sessionToken;
-	const stepOffset = state.source === "new" ? 1 : 0;
+const toolCategories = [
+	{
+		icon: Wallet,
+		name: "Wallet",
+		description:
+			"Send BSV, manage UTXOs, inscribe files and mint collections from a local key, a BRC-100 signer, or a Droplit-sponsored wallet.",
+	},
+	{
+		icon: ImageIcon,
+		name: "Ordinals",
+		description:
+			"Look up 1Sat Ordinals, browse marketplace listings, and buy or list NFTs directly from a conversation.",
+	},
+	{
+		icon: Search,
+		name: "Explorer",
+		description:
+			"Decode raw transactions, fetch blocks and addresses, and pull the live BSV price with built-in caching.",
+	},
+	{
+		icon: Fingerprint,
+		name: "Identity",
+		description:
+			"Create and manage Bitcoin Attestation Protocol (BAP) identities and sign attestations on-chain.",
+	},
+	{
+		icon: MessageSquare,
+		name: "Social",
+		description:
+			"Post, like, and follow on BSocial. Your agent can publish to the open social graph.",
+	},
+	{
+		icon: Bitcoin,
+		name: "Tokens",
+		description:
+			"Check balances and transfer MNEE stablecoin, with utilities for encoding, hashing, and data conversion.",
+	},
+];
 
+const steps = [
+	{
+		title: "Install",
+		description:
+			"One plugin command for Claude Code, a JSON snippet for Cursor or Claude Desktop, or a hosted URL. No build step.",
+	},
+	{
+		title: "Connect a key",
+		description:
+			"Bring a WIF, point at an existing BRC-100 wallet, or let the server generate an encrypted key on first run.",
+	},
+	{
+		title: "Ask",
+		description:
+			"“Inscribe this SVG”, “what's in block 900000”, “send 5000 sats to…”. The agent picks the right tool and shows you the txid.",
+	},
+];
+
+const deployModes = [
+	{
+		icon: Terminal,
+		title: "Local",
+		subtitle: "stdio transport",
+		description:
+			"Runs on your machine with keys encrypted at rest. The default for Claude Code and desktop clients.",
+	},
+	{
+		icon: Server,
+		title: "HTTP",
+		subtitle: "Streamable HTTP",
+		description:
+			"Self-host the MCP 2025-03-26 Streamable HTTP endpoint with OAuth 2.1 and JWT validation.",
+	},
+	{
+		icon: Cloud,
+		title: "Hosted",
+		subtitle: "bsvmcp.com",
+		description:
+			"Authenticate with a Bitcoin signature and get a ready-to-paste config. Nothing to run.",
+	},
+];
+
+function TerminalDemo() {
 	return (
-		<div className="min-h-screen flex items-center justify-center p-4">
-			<div className="w-full max-w-lg space-y-6">
-				{/* Header */}
-				<div className="text-center space-y-1">
-					<h1 className="text-3xl font-bold tracking-tight">BSV MCP</h1>
-					<p className="text-muted-foreground text-sm">
-						Model Context Protocol for Bitcoin SV
+		<div className="min-w-0 overflow-hidden rounded-xl border border-border bg-[#0b0f1a] shadow-2xl shadow-amber-500/5">
+			<div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+				<span className="size-2.5 rounded-full bg-red-500/70" />
+				<span className="size-2.5 rounded-full bg-yellow-500/70" />
+				<span className="size-2.5 rounded-full bg-green-500/70" />
+				<span className="ml-2 font-mono text-xs text-muted-foreground">
+					claude
+				</span>
+			</div>
+			<div className="space-y-4 break-words p-5 font-mono text-[13px] leading-relaxed">
+				<div>
+					<span className="text-amber-400">&gt; </span>
+					<span className="text-foreground">
+						inscribe hello.svg as a 1sat ordinal and tell me the txid
+					</span>
+				</div>
+				<div className="space-y-1 text-muted-foreground">
+					<p>
+						<span className="text-emerald-400">●</span>{" "}
+						wallet_createOrdinals(file: "hello.svg", contentType:
+						"image/svg+xml")
 					</p>
-					<p className="text-xs text-muted-foreground/60">
-						MCP 2025-03-26 Specification
+					<p className="pl-4 text-muted-foreground/70">
+						├ reading file (412 bytes)
+					</p>
+					<p className="pl-4 text-muted-foreground/70">
+						├ selecting UTXOs · fee 1 sat/kb
+					</p>
+					<p className="pl-4 text-muted-foreground/70">└ broadcast ✓</p>
+				</div>
+				<div className="text-foreground">
+					Inscribed. Outpoint{" "}
+					<span className="text-amber-300">f3a1…9c2e_0</span> — view it on{" "}
+					<span className="underline decoration-muted-foreground/40">
+						1satordinals.com
+					</span>
+					.
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default function LandingPage() {
+	return (
+		<div className="relative min-h-screen overflow-x-hidden">
+			{/* Background glow */}
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[640px] bg-[radial-gradient(ellipse_at_top,rgba(245,158,11,0.16),transparent_60%)]"
+			/>
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(to_right,rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.03)_1px,transparent_1px)] bg-[size:48px_48px] [mask-image:radial-gradient(ellipse_at_top,black,transparent_70%)]"
+			/>
+
+			{/* Nav */}
+			<header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
+				<Link href="/" className="flex items-center gap-2 font-semibold">
+					<span className="flex size-7 items-center justify-center rounded-md bg-amber-500 text-black">
+						<Bitcoin className="size-4" />
+					</span>
+					BSV MCP
+				</Link>
+				<nav className="flex items-center gap-1 text-sm">
+					<a
+						href="#tools"
+						className="hidden rounded-md px-3 py-2 text-muted-foreground hover:text-foreground sm:block"
+					>
+						Tools
+					</a>
+					<a
+						href="#install"
+						className="hidden rounded-md px-3 py-2 text-muted-foreground hover:text-foreground sm:block"
+					>
+						Install
+					</a>
+					<a
+						href={GITHUB_URL}
+						target="_blank"
+						rel="noreferrer"
+						className="flex items-center gap-1.5 rounded-md px-3 py-2 text-muted-foreground hover:text-foreground"
+					>
+						<Github className="size-4" />
+						<span className="hidden sm:inline">GitHub</span>
+					</a>
+					<Link
+						href="/connect"
+						className="ml-2 rounded-md bg-foreground px-3.5 py-2 font-medium text-background hover:bg-foreground/90"
+					>
+						Get started
+					</Link>
+				</nav>
+			</header>
+
+			{/* Hero */}
+			<section className="mx-auto grid max-w-6xl items-center gap-12 px-6 pb-20 pt-12 lg:grid-cols-[1.1fr_1fr] lg:pt-20">
+				<div className="min-w-0 space-y-7">
+					<div className="inline-flex items-center gap-2 rounded-full border border-border bg-card/60 px-3 py-1 text-xs text-muted-foreground">
+						<span className="size-1.5 rounded-full bg-emerald-400" />
+						Open source · MCP 2025-03-26 · v0.3
+					</div>
+					<h1 className="text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl">
+						Give your AI agent a{" "}
+						<span className="bg-gradient-to-r from-amber-300 to-amber-500 bg-clip-text text-transparent">
+							Bitcoin wallet
+						</span>
+						.
+					</h1>
+					<p className="max-w-xl text-lg text-muted-foreground">
+						BSV MCP is a Model Context Protocol server that lets Claude, Cursor,
+						and any MCP client send BSV, inscribe ordinals, manage on-chain
+						identity, and read the blockchain. Eighty-plus tools, one install.
+					</p>
+					<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+						<Link
+							href="/connect"
+							className="inline-flex items-center justify-center gap-2 rounded-md bg-amber-500 px-5 py-2.5 text-sm font-semibold text-black hover:bg-amber-400"
+						>
+							Connect the hosted server
+							<ArrowRight className="size-4" />
+						</Link>
+						<a
+							href="#install"
+							className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-card/60 px-5 py-2.5 text-sm font-medium hover:bg-accent"
+						>
+							<Terminal className="size-4" />
+							Run it locally
+						</a>
+					</div>
+					<CopyCommand
+						command="claude plugin install bsv-mcp@b-open-io"
+						className="max-w-xl"
+					/>
+				</div>
+				<TerminalDemo />
+			</section>
+
+			{/* Logos / clients */}
+			<section className="border-y border-border bg-card/30">
+				<div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-10 gap-y-3 px-6 py-6 text-sm text-muted-foreground">
+					<span className="text-xs uppercase tracking-wider">Works with</span>
+					<span>Claude Code</span>
+					<span>Claude Desktop</span>
+					<span>Cursor</span>
+					<span>Windsurf</span>
+					<span>Any MCP client</span>
+				</div>
+			</section>
+
+			{/* How it works */}
+			<section className="mx-auto max-w-6xl px-6 py-20">
+				<div className="mb-10 max-w-2xl">
+					<h2 className="text-3xl font-bold tracking-tight">
+						From prompt to txid in three steps
+					</h2>
+					<p className="mt-3 text-muted-foreground">
+						No SDK to learn. The agent reads the tool schemas and does the rest.
 					</p>
 				</div>
+				<ol className="grid gap-6 md:grid-cols-3">
+					{steps.map((step, i) => (
+						<li
+							key={step.title}
+							className="rounded-xl border border-border bg-card/40 p-6"
+						>
+							<span className="font-mono text-xs text-amber-400">0{i + 1}</span>
+							<h3 className="mt-2 text-lg font-semibold">{step.title}</h3>
+							<p className="mt-2 text-sm text-muted-foreground">
+								{step.description}
+							</p>
+						</li>
+					))}
+				</ol>
+			</section>
 
-				{/* Auth card */}
-				<Card>
-					<CardHeader>
-						<CardTitle>Authenticate</CardTitle>
-						<CardDescription>
-							Generate a new Bitcoin key or import an existing backup to connect
-							to the hosted MCP server.
-						</CardDescription>
-					</CardHeader>
-					<CardContent>
-						<KeySetup
-							state={state}
-							dispatch={dispatch}
-							fileInputRef={fileInputRef}
-							onGenerate={generateNewKey}
-							onFileSelect={handleFileSelect}
-							onDecrypt={decryptBackup}
-							onAuthenticate={authenticate}
-						/>
-					</CardContent>
-				</Card>
+			{/* Tools */}
+			<section id="tools" className="mx-auto max-w-6xl px-6 pb-20">
+				<div className="mb-10 flex flex-wrap items-end justify-between gap-4">
+					<div className="max-w-2xl">
+						<h2 className="text-3xl font-bold tracking-tight">
+							Everything on-chain, as tools
+						</h2>
+						<p className="mt-3 text-muted-foreground">
+							Each category can be toggled with an environment variable. Tools
+							that need keys fail gracefully when none are configured.
+						</p>
+					</div>
+					<a
+						href={`${GITHUB_URL}#readme`}
+						target="_blank"
+						rel="noreferrer"
+						className="inline-flex items-center gap-1 text-sm text-amber-400 hover:text-amber-300"
+					>
+						Full tool reference <ArrowRight className="size-4" />
+					</a>
+				</div>
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{toolCategories.map(({ icon: Icon, name, description }) => (
+						<div
+							key={name}
+							className="group rounded-xl border border-border bg-card/40 p-6 transition-colors hover:border-amber-500/40"
+						>
+							<div className="flex size-10 items-center justify-center rounded-lg bg-amber-500/10 text-amber-400">
+								<Icon className="size-5" />
+							</div>
+							<h3 className="mt-4 font-semibold">{name}</h3>
+							<p className="mt-2 text-sm text-muted-foreground">
+								{description}
+							</p>
+						</div>
+					))}
+				</div>
+			</section>
 
-				{/* Post-auth steps */}
-				{isAuthenticated && (
-					<>
-						{/* Step 1: Backup (new keys only) */}
-						{state.source === "new" && (
-							<Card>
-								<CardHeader>
-									<CardTitle>Step 1: Download Your Backup</CardTitle>
-									<CardDescription>
-										Save your private key before proceeding. You cannot recover
-										it without this file.
-									</CardDescription>
-								</CardHeader>
-								<CardContent>
-									<BackupSection onDownload={downloadBackup} />
-								</CardContent>
-							</Card>
-						)}
+			{/* Install */}
+			<section id="install" className="border-t border-border bg-card/20">
+				<div className="mx-auto max-w-6xl px-6 py-20">
+					<div className="mb-10 max-w-2xl">
+						<h2 className="text-3xl font-bold tracking-tight">
+							Run it your way
+						</h2>
+						<p className="mt-3 text-muted-foreground">
+							The same server ships in three shapes. Pick the one that fits your
+							client and your key custody.
+						</p>
+					</div>
+					<div className="grid gap-4 md:grid-cols-3">
+						{deployModes.map(({ icon: Icon, title, subtitle, description }) => (
+							<div
+								key={title}
+								className="rounded-xl border border-border bg-card/40 p-6"
+							>
+								<div className="flex items-center gap-3">
+									<Icon className="size-5 text-amber-400" />
+									<div>
+										<h3 className="font-semibold">{title}</h3>
+										<p className="font-mono text-xs text-muted-foreground">
+											{subtitle}
+										</p>
+									</div>
+								</div>
+								<p className="mt-4 text-sm text-muted-foreground">
+									{description}
+								</p>
+							</div>
+						))}
+					</div>
 
-						{/* Step 2 (or 1 for imported keys): Config */}
-						<Card>
-							<CardHeader>
-								<CardTitle>
-									Step {stepOffset + 1}: Installation &amp; Configuration
-								</CardTitle>
-								<CardDescription>
-									Choose your platform and copy the configuration snippet.
-								</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<ConfigTabs
-									mcpUrl={state.mcpUrl}
-									sessionToken={state.sessionToken}
-									copied={state.copied}
-									onCopy={copyToClipboard}
-								/>
-							</CardContent>
-						</Card>
-					</>
-				)}
-			</div>
+					<div className="mt-10 grid gap-6 lg:grid-cols-2">
+						<div className="space-y-3">
+							<p className="flex items-center gap-2 text-sm font-medium">
+								<Plug className="size-4 text-amber-400" />
+								Claude Code
+							</p>
+							<CopyCommand command="claude plugin install bsv-mcp@b-open-io" />
+							<p className="flex items-center gap-2 pt-2 text-sm font-medium">
+								<Wrench className="size-4 text-amber-400" />
+								Any stdio client
+							</p>
+							<CopyCommand command="bunx bsv-mcp@latest" />
+						</div>
+						<div className="space-y-3">
+							<p className="flex items-center gap-2 text-sm font-medium">
+								<Blocks className="size-4 text-amber-400" />
+								Cursor / Claude Desktop
+							</p>
+							<pre className="overflow-x-auto rounded-lg border border-border bg-black/40 p-4 font-mono text-xs leading-relaxed text-foreground">
+								{`{
+  "mcpServers": {
+    "bsv-mcp": {
+      "command": "bunx",
+      "args": ["bsv-mcp@latest"]
+    }
+  }
+}`}
+							</pre>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			{/* Security */}
+			<section className="mx-auto max-w-6xl px-6 py-20">
+				<div className="grid gap-8 lg:grid-cols-[1fr_1.2fr] lg:items-center">
+					<div>
+						<h2 className="text-3xl font-bold tracking-tight">
+							Keys stay yours
+						</h2>
+						<p className="mt-3 text-muted-foreground">
+							An agent with a wallet needs guardrails. BSV MCP is built so the
+							model can act without ever seeing raw key material in a prompt.
+						</p>
+					</div>
+					<ul className="grid gap-4 sm:grid-cols-2">
+						{[
+							{
+								icon: KeyRound,
+								title: "Encrypted at rest",
+								text: "AES-256-GCM with 600k PBKDF2 iterations in the bitcoin-backup format. Files are created with 0600 permissions.",
+							},
+							{
+								icon: ShieldCheck,
+								title: "No passphrase env vars",
+								text: "Passphrases are entered through a temporary local web prompt, never read from the environment.",
+							},
+							{
+								icon: Fingerprint,
+								title: "Bitcoin-signed auth",
+								text: "Hosted mode uses OAuth 2.1 via sigma-auth. Your public key is your identity. Nothing to register.",
+							},
+							{
+								icon: Wallet,
+								title: "External signers",
+								text: "Point at a BRC-100 wallet and it stays the permission authority. Every spend is approved there.",
+							},
+						].map(({ icon: Icon, title, text }) => (
+							<li
+								key={title}
+								className="rounded-xl border border-border bg-card/40 p-5"
+							>
+								<Icon className="size-5 text-amber-400" />
+								<h3 className="mt-3 font-semibold">{title}</h3>
+								<p className="mt-1.5 text-sm text-muted-foreground">{text}</p>
+							</li>
+						))}
+					</ul>
+				</div>
+			</section>
+
+			{/* CTA */}
+			<section className="mx-auto max-w-6xl px-6 pb-24">
+				<div className="relative overflow-hidden rounded-2xl border border-amber-500/30 bg-gradient-to-br from-amber-500/15 via-card to-card p-10 text-center">
+					<h2 className="text-3xl font-bold tracking-tight">
+						Put your agent on-chain
+					</h2>
+					<p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+						Generate a key, download the backup, paste the config. You'll be
+						sending a transaction from a chat window in under two minutes.
+					</p>
+					<div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+						<Link
+							href="/connect"
+							className="inline-flex items-center justify-center gap-2 rounded-md bg-amber-500 px-5 py-2.5 text-sm font-semibold text-black hover:bg-amber-400"
+						>
+							Get started <ArrowRight className="size-4" />
+						</Link>
+						<a
+							href={GITHUB_URL}
+							target="_blank"
+							rel="noreferrer"
+							className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-background/60 px-5 py-2.5 text-sm font-medium hover:bg-accent"
+						>
+							<Github className="size-4" /> Star on GitHub
+						</a>
+					</div>
+				</div>
+			</section>
+
+			{/* Footer */}
+			<footer className="border-t border-border">
+				<div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-8 text-sm text-muted-foreground">
+					<p>© {new Date().getFullYear()} BSV MCP · MIT License</p>
+					<div className="flex gap-6">
+						<a
+							href={GITHUB_URL}
+							target="_blank"
+							rel="noreferrer"
+							className="hover:text-foreground"
+						>
+							GitHub
+						</a>
+						<a
+							href={NPM_URL}
+							target="_blank"
+							rel="noreferrer"
+							className="hover:text-foreground"
+						>
+							npm
+						</a>
+						<a
+							href="https://modelcontextprotocol.io"
+							target="_blank"
+							rel="noreferrer"
+							className="hover:text-foreground"
+						>
+							MCP spec
+						</a>
+						<Link href="/connect" className="hover:text-foreground">
+							Hosted service
+						</Link>
+					</div>
+				</div>
+			</footer>
 		</div>
 	);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,6 +30,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { approximateTotal, countTools, getToolCounts } from "@/lib/tool-count";
 
 const GITHUB_URL = "https://github.com/b-open-io/bsv-mcp";
 const NPM_URL = "https://www.npmjs.com/package/bsv-mcp";
@@ -42,40 +43,51 @@ const clients = [
 	"Any MCP client",
 ];
 
-const toolCategories = [
+const toolCategories: {
+	icon: typeof Wallet;
+	name: string;
+	directories: string[];
+	description: string;
+}[] = [
 	{
 		icon: Wallet,
 		name: "Wallet",
+		directories: ["wallet"],
 		description:
 			"Send BSV, manage UTXOs, inscribe files and mint collections from a local key, a BRC-100 signer, or a Droplit-sponsored wallet.",
 	},
 	{
 		icon: ImageIcon,
 		name: "Ordinals",
+		directories: ["ordinals"],
 		description:
 			"Look up 1Sat Ordinals, browse marketplace listings, and buy or list NFTs directly from a conversation.",
 	},
 	{
 		icon: Search,
 		name: "Explorer",
+		directories: ["bsv"],
 		description:
 			"Decode raw transactions, fetch blocks and addresses, and pull the live BSV price with built-in caching.",
 	},
 	{
 		icon: Fingerprint,
 		name: "Identity",
+		directories: ["bap"],
 		description:
 			"Create and manage Bitcoin Attestation Protocol (BAP) identities and sign attestations on-chain.",
 	},
 	{
 		icon: MessageSquare,
 		name: "Social",
+		directories: ["bsocial"],
 		description:
 			"Post, like, and follow on BSocial. Your agent can publish to the open social graph.",
 	},
 	{
 		icon: Bitcoin,
 		name: "Tokens",
+		directories: ["mnee", "utils"],
 		description:
 			"Check balances and transfer MNEE stablecoin, with utilities for encoding, hashing, and data conversion.",
 	},
@@ -180,6 +192,9 @@ function SectionHeading({
 }
 
 export default function LandingPage() {
+	const toolCounts = getToolCounts();
+	const headlineTotal = approximateTotal(toolCounts.total);
+
 	return (
 		<div className="relative min-h-screen overflow-x-hidden">
 			<div
@@ -230,7 +245,10 @@ export default function LandingPage() {
 					<p className="max-w-xl text-lg text-muted-foreground">
 						BSV MCP is a Model Context Protocol server that lets Claude, Cursor,
 						and any MCP client send BSV, inscribe ordinals, manage on-chain
-						identity, and read the blockchain. Eighty-plus tools, one install.
+						identity, and read the blockchain.{" "}
+						{headlineTotal
+							? `${headlineTotal} tools, one install.`
+							: "One install."}
 					</p>
 					<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
 						<Button size="xl" asChild>
@@ -299,20 +317,32 @@ export default function LandingPage() {
 					}
 				/>
 				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{toolCategories.map(({ icon: Icon, name, description }) => (
-						<Card
-							key={name}
-							className="h-full bg-card/60 transition-colors hover:border-primary/40"
-						>
-							<CardHeader>
-								<span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-									<Icon className="size-5" />
-								</span>
-								<CardTitle className="pt-2">{name}</CardTitle>
-								<CardDescription>{description}</CardDescription>
-							</CardHeader>
-						</Card>
-					))}
+					{toolCategories.map(
+						({ icon: Icon, name, directories, description }) => {
+							const count = countTools(toolCounts, directories);
+							return (
+								<Card
+									key={name}
+									className="h-full bg-card/60 transition-colors hover:border-primary/40"
+								>
+									<CardHeader>
+										<div className="flex items-start justify-between gap-3">
+											<span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+												<Icon className="size-5" />
+											</span>
+											{count > 0 && (
+												<Badge variant="secondary">
+													{count} {count === 1 ? "tool" : "tools"}
+												</Badge>
+											)}
+										</div>
+										<CardTitle className="pt-2">{name}</CardTitle>
+										<CardDescription>{description}</CardDescription>
+									</CardHeader>
+								</Card>
+							);
+						},
+					)}
 				</div>
 			</section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,10 +17,30 @@ import {
 	Wrench,
 } from "lucide-react";
 import Link from "next/link";
+import { CodeSnippet } from "@/components/landing/CodeSnippet";
 import { CopyCommand } from "@/components/landing/CopyCommand";
+import { TerminalDemo } from "@/components/landing/TerminalDemo";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 
 const GITHUB_URL = "https://github.com/b-open-io/bsv-mcp";
 const NPM_URL = "https://www.npmjs.com/package/bsv-mcp";
+
+const clients = [
+	"Claude Code",
+	"Claude Desktop",
+	"Cursor",
+	"Windsurf",
+	"Any MCP client",
+];
 
 const toolCategories = [
 	{
@@ -103,47 +123,58 @@ const deployModes = [
 	},
 ];
 
-function TerminalDemo() {
+const guarantees = [
+	{
+		icon: KeyRound,
+		title: "Encrypted at rest",
+		description:
+			"AES-256-GCM with 600k PBKDF2 iterations in the bitcoin-backup format. Files are created with 0600 permissions.",
+	},
+	{
+		icon: ShieldCheck,
+		title: "No passphrase env vars",
+		description:
+			"Passphrases are entered through a temporary local web prompt, never read from the environment.",
+	},
+	{
+		icon: Fingerprint,
+		title: "Bitcoin-signed auth",
+		description:
+			"Hosted mode uses OAuth 2.1 via sigma-auth. Your public key is your identity. Nothing to register.",
+	},
+	{
+		icon: Wallet,
+		title: "External signers",
+		description:
+			"Point at a BRC-100 wallet and it stays the permission authority. Every spend is approved there.",
+	},
+];
+
+const clientConfig = `{
+  "mcpServers": {
+    "bsv-mcp": {
+      "command": "bunx",
+      "args": ["bsv-mcp@latest"]
+    }
+  }
+}`;
+
+function SectionHeading({
+	title,
+	description,
+	action,
+}: {
+	title: string;
+	description: string;
+	action?: React.ReactNode;
+}) {
 	return (
-		<div className="min-w-0 overflow-hidden rounded-xl border border-border bg-[#0b0f1a] shadow-2xl shadow-amber-500/5">
-			<div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
-				<span className="size-2.5 rounded-full bg-red-500/70" />
-				<span className="size-2.5 rounded-full bg-yellow-500/70" />
-				<span className="size-2.5 rounded-full bg-green-500/70" />
-				<span className="ml-2 font-mono text-xs text-muted-foreground">
-					claude
-				</span>
+		<div className="mb-10 flex flex-wrap items-end justify-between gap-4">
+			<div className="max-w-2xl space-y-3">
+				<h2 className="text-3xl font-bold tracking-tight">{title}</h2>
+				<p className="text-muted-foreground">{description}</p>
 			</div>
-			<div className="space-y-4 break-words p-5 font-mono text-[13px] leading-relaxed">
-				<div>
-					<span className="text-amber-400">&gt; </span>
-					<span className="text-foreground">
-						inscribe hello.svg as a 1sat ordinal and tell me the txid
-					</span>
-				</div>
-				<div className="space-y-1 text-muted-foreground">
-					<p>
-						<span className="text-emerald-400">●</span>{" "}
-						wallet_createOrdinals(file: "hello.svg", contentType:
-						"image/svg+xml")
-					</p>
-					<p className="pl-4 text-muted-foreground/70">
-						├ reading file (412 bytes)
-					</p>
-					<p className="pl-4 text-muted-foreground/70">
-						├ selecting UTXOs · fee 1 sat/kb
-					</p>
-					<p className="pl-4 text-muted-foreground/70">└ broadcast ✓</p>
-				</div>
-				<div className="text-foreground">
-					Inscribed. Outpoint{" "}
-					<span className="text-amber-300">f3a1…9c2e_0</span> — view it on{" "}
-					<span className="underline decoration-muted-foreground/40">
-						1satordinals.com
-					</span>
-					.
-				</div>
-			</div>
+			{action}
 		</div>
 	);
 }
@@ -151,68 +182,50 @@ function TerminalDemo() {
 export default function LandingPage() {
 	return (
 		<div className="relative min-h-screen overflow-x-hidden">
-			{/* Background glow */}
 			<div
 				aria-hidden
-				className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[640px] bg-[radial-gradient(ellipse_at_top,rgba(245,158,11,0.16),transparent_60%)]"
+				className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[640px] bg-[radial-gradient(ellipse_at_top,hsl(var(--primary)/0.16),transparent_60%)]"
 			/>
 			<div
 				aria-hidden
-				className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(to_right,rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.03)_1px,transparent_1px)] bg-[size:48px_48px] [mask-image:radial-gradient(ellipse_at_top,black,transparent_70%)]"
+				className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(to_right,hsl(var(--border)/0.5)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border)/0.5)_1px,transparent_1px)] bg-[size:48px_48px] [mask-image:radial-gradient(ellipse_at_top,black,transparent_70%)]"
 			/>
 
-			{/* Nav */}
 			<header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
 				<Link href="/" className="flex items-center gap-2 font-semibold">
-					<span className="flex size-7 items-center justify-center rounded-md bg-amber-500 text-black">
+					<span className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground">
 						<Bitcoin className="size-4" />
 					</span>
 					BSV MCP
 				</Link>
-				<nav className="flex items-center gap-1 text-sm">
-					<a
-						href="#tools"
-						className="hidden rounded-md px-3 py-2 text-muted-foreground hover:text-foreground sm:block"
-					>
-						Tools
-					</a>
-					<a
-						href="#install"
-						className="hidden rounded-md px-3 py-2 text-muted-foreground hover:text-foreground sm:block"
-					>
-						Install
-					</a>
-					<a
-						href={GITHUB_URL}
-						target="_blank"
-						rel="noreferrer"
-						className="flex items-center gap-1.5 rounded-md px-3 py-2 text-muted-foreground hover:text-foreground"
-					>
-						<Github className="size-4" />
-						<span className="hidden sm:inline">GitHub</span>
-					</a>
-					<Link
-						href="/connect"
-						className="ml-2 rounded-md bg-foreground px-3.5 py-2 font-medium text-background hover:bg-foreground/90"
-					>
-						Get started
-					</Link>
+				<nav className="flex items-center gap-1">
+					<Button variant="ghost" asChild className="hidden sm:inline-flex">
+						<a href="#tools">Tools</a>
+					</Button>
+					<Button variant="ghost" asChild className="hidden sm:inline-flex">
+						<a href="#install">Install</a>
+					</Button>
+					<Button variant="ghost" asChild>
+						<a href={GITHUB_URL} target="_blank" rel="noreferrer">
+							<Github />
+							<span className="hidden sm:inline">GitHub</span>
+						</a>
+					</Button>
+					<Button asChild className="ml-2">
+						<Link href="/connect">Get started</Link>
+					</Button>
 				</nav>
 			</header>
 
-			{/* Hero */}
 			<section className="mx-auto grid max-w-6xl items-center gap-12 px-6 pb-20 pt-12 lg:grid-cols-[1.1fr_1fr] lg:pt-20">
 				<div className="min-w-0 space-y-7">
-					<div className="inline-flex items-center gap-2 rounded-full border border-border bg-card/60 px-3 py-1 text-xs text-muted-foreground">
-						<span className="size-1.5 rounded-full bg-emerald-400" />
+					<Badge variant="outline" className="py-1">
+						<span aria-hidden className="size-1.5 rounded-full bg-success" />
 						Open source · MCP 2025-03-26 · v0.3
-					</div>
+					</Badge>
 					<h1 className="text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl">
 						Give your AI agent a{" "}
-						<span className="bg-gradient-to-r from-amber-300 to-amber-500 bg-clip-text text-transparent">
-							Bitcoin wallet
-						</span>
-						.
+						<span className="text-primary">Bitcoin wallet</span>.
 					</h1>
 					<p className="max-w-xl text-lg text-muted-foreground">
 						BSV MCP is a Model Context Protocol server that lets Claude, Cursor,
@@ -220,20 +233,18 @@ export default function LandingPage() {
 						identity, and read the blockchain. Eighty-plus tools, one install.
 					</p>
 					<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-						<Link
-							href="/connect"
-							className="inline-flex items-center justify-center gap-2 rounded-md bg-amber-500 px-5 py-2.5 text-sm font-semibold text-black hover:bg-amber-400"
-						>
-							Connect the hosted server
-							<ArrowRight className="size-4" />
-						</Link>
-						<a
-							href="#install"
-							className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-card/60 px-5 py-2.5 text-sm font-medium hover:bg-accent"
-						>
-							<Terminal className="size-4" />
-							Run it locally
-						</a>
+						<Button size="xl" asChild>
+							<Link href="/connect">
+								Connect the hosted server
+								<ArrowRight />
+							</Link>
+						</Button>
+						<Button size="xl" variant="outline" asChild>
+							<a href="#install">
+								<Terminal />
+								Run it locally
+							</a>
+						</Button>
 					</div>
 					<CopyCommand
 						command="claude plugin install bsv-mcp@b-open-io"
@@ -243,232 +254,180 @@ export default function LandingPage() {
 				<TerminalDemo />
 			</section>
 
-			{/* Logos / clients */}
-			<section className="border-y border-border bg-card/30">
+			<section className="border-y bg-card/40">
 				<div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-10 gap-y-3 px-6 py-6 text-sm text-muted-foreground">
 					<span className="text-xs uppercase tracking-wider">Works with</span>
-					<span>Claude Code</span>
-					<span>Claude Desktop</span>
-					<span>Cursor</span>
-					<span>Windsurf</span>
-					<span>Any MCP client</span>
+					{clients.map((client) => (
+						<span key={client}>{client}</span>
+					))}
 				</div>
 			</section>
 
-			{/* How it works */}
 			<section className="mx-auto max-w-6xl px-6 py-20">
-				<div className="mb-10 max-w-2xl">
-					<h2 className="text-3xl font-bold tracking-tight">
-						From prompt to txid in three steps
-					</h2>
-					<p className="mt-3 text-muted-foreground">
-						No SDK to learn. The agent reads the tool schemas and does the rest.
-					</p>
-				</div>
+				<SectionHeading
+					title="From prompt to txid in three steps"
+					description="No SDK to learn. The agent reads the tool schemas and does the rest."
+				/>
 				<ol className="grid gap-6 md:grid-cols-3">
-					{steps.map((step, i) => (
-						<li
-							key={step.title}
-							className="rounded-xl border border-border bg-card/40 p-6"
-						>
-							<span className="font-mono text-xs text-amber-400">0{i + 1}</span>
-							<h3 className="mt-2 text-lg font-semibold">{step.title}</h3>
-							<p className="mt-2 text-sm text-muted-foreground">
-								{step.description}
-							</p>
+					{steps.map((step, index) => (
+						<li key={step.title}>
+							<Card className="h-full bg-card/60">
+								<CardHeader>
+									<span className="font-mono text-xs text-primary">
+										0{index + 1}
+									</span>
+									<CardTitle className="text-lg">{step.title}</CardTitle>
+									<CardDescription>{step.description}</CardDescription>
+								</CardHeader>
+							</Card>
 						</li>
 					))}
 				</ol>
 			</section>
 
-			{/* Tools */}
 			<section id="tools" className="mx-auto max-w-6xl px-6 pb-20">
-				<div className="mb-10 flex flex-wrap items-end justify-between gap-4">
-					<div className="max-w-2xl">
-						<h2 className="text-3xl font-bold tracking-tight">
-							Everything on-chain, as tools
-						</h2>
-						<p className="mt-3 text-muted-foreground">
-							Each category can be toggled with an environment variable. Tools
-							that need keys fail gracefully when none are configured.
-						</p>
-					</div>
-					<a
-						href={`${GITHUB_URL}#readme`}
-						target="_blank"
-						rel="noreferrer"
-						className="inline-flex items-center gap-1 text-sm text-amber-400 hover:text-amber-300"
-					>
-						Full tool reference <ArrowRight className="size-4" />
-					</a>
-				</div>
+				<SectionHeading
+					title="Everything on-chain, as tools"
+					description="Each category can be toggled with an environment variable. Tools that need keys fail gracefully when none are configured."
+					action={
+						<Button variant="link" asChild className="px-0">
+							<a href={`${GITHUB_URL}#readme`} target="_blank" rel="noreferrer">
+								Full tool reference
+								<ArrowRight />
+							</a>
+						</Button>
+					}
+				/>
 				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{toolCategories.map(({ icon: Icon, name, description }) => (
-						<div
+						<Card
 							key={name}
-							className="group rounded-xl border border-border bg-card/40 p-6 transition-colors hover:border-amber-500/40"
+							className="h-full bg-card/60 transition-colors hover:border-primary/40"
 						>
-							<div className="flex size-10 items-center justify-center rounded-lg bg-amber-500/10 text-amber-400">
-								<Icon className="size-5" />
-							</div>
-							<h3 className="mt-4 font-semibold">{name}</h3>
-							<p className="mt-2 text-sm text-muted-foreground">
-								{description}
-							</p>
-						</div>
+							<CardHeader>
+								<span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+									<Icon className="size-5" />
+								</span>
+								<CardTitle className="pt-2">{name}</CardTitle>
+								<CardDescription>{description}</CardDescription>
+							</CardHeader>
+						</Card>
 					))}
 				</div>
 			</section>
 
-			{/* Install */}
-			<section id="install" className="border-t border-border bg-card/20">
+			<section id="install" className="border-t bg-card/30">
 				<div className="mx-auto max-w-6xl px-6 py-20">
-					<div className="mb-10 max-w-2xl">
-						<h2 className="text-3xl font-bold tracking-tight">
-							Run it your way
-						</h2>
-						<p className="mt-3 text-muted-foreground">
-							The same server ships in three shapes. Pick the one that fits your
-							client and your key custody.
-						</p>
-					</div>
+					<SectionHeading
+						title="Run it your way"
+						description="The same server ships in three shapes. Pick the one that fits your client and your key custody."
+					/>
 					<div className="grid gap-4 md:grid-cols-3">
 						{deployModes.map(({ icon: Icon, title, subtitle, description }) => (
-							<div
-								key={title}
-								className="rounded-xl border border-border bg-card/40 p-6"
-							>
-								<div className="flex items-center gap-3">
-									<Icon className="size-5 text-amber-400" />
-									<div>
-										<h3 className="font-semibold">{title}</h3>
-										<p className="font-mono text-xs text-muted-foreground">
-											{subtitle}
-										</p>
+							<Card key={title} className="h-full bg-card/60">
+								<CardHeader>
+									<div className="flex items-center gap-3">
+										<Icon className="size-5 text-primary" />
+										<div>
+											<CardTitle>{title}</CardTitle>
+											<p className="font-mono text-xs text-muted-foreground">
+												{subtitle}
+											</p>
+										</div>
 									</div>
-								</div>
-								<p className="mt-4 text-sm text-muted-foreground">
-									{description}
-								</p>
-							</div>
+									<CardDescription className="pt-2">
+										{description}
+									</CardDescription>
+								</CardHeader>
+							</Card>
 						))}
 					</div>
 
-					<div className="mt-10 grid gap-6 lg:grid-cols-2">
+					<Separator className="my-10" />
+
+					<div className="grid gap-6 lg:grid-cols-2">
 						<div className="space-y-3">
 							<p className="flex items-center gap-2 text-sm font-medium">
-								<Plug className="size-4 text-amber-400" />
+								<Plug className="size-4 text-primary" />
 								Claude Code
 							</p>
 							<CopyCommand command="claude plugin install bsv-mcp@b-open-io" />
 							<p className="flex items-center gap-2 pt-2 text-sm font-medium">
-								<Wrench className="size-4 text-amber-400" />
+								<Wrench className="size-4 text-primary" />
 								Any stdio client
 							</p>
 							<CopyCommand command="bunx bsv-mcp@latest" />
 						</div>
 						<div className="space-y-3">
 							<p className="flex items-center gap-2 text-sm font-medium">
-								<Blocks className="size-4 text-amber-400" />
+								<Blocks className="size-4 text-primary" />
 								Cursor / Claude Desktop
 							</p>
-							<pre className="overflow-x-auto rounded-lg border border-border bg-black/40 p-4 font-mono text-xs leading-relaxed text-foreground">
-								{`{
-  "mcpServers": {
-    "bsv-mcp": {
-      "command": "bunx",
-      "args": ["bsv-mcp@latest"]
-    }
-  }
-}`}
-							</pre>
+							<CodeSnippet code={clientConfig} />
 						</div>
 					</div>
 				</div>
 			</section>
 
-			{/* Security */}
 			<section className="mx-auto max-w-6xl px-6 py-20">
 				<div className="grid gap-8 lg:grid-cols-[1fr_1.2fr] lg:items-center">
-					<div>
+					<div className="space-y-3">
 						<h2 className="text-3xl font-bold tracking-tight">
 							Keys stay yours
 						</h2>
-						<p className="mt-3 text-muted-foreground">
+						<p className="text-muted-foreground">
 							An agent with a wallet needs guardrails. BSV MCP is built so the
 							model can act without ever seeing raw key material in a prompt.
 						</p>
 					</div>
 					<ul className="grid gap-4 sm:grid-cols-2">
-						{[
-							{
-								icon: KeyRound,
-								title: "Encrypted at rest",
-								text: "AES-256-GCM with 600k PBKDF2 iterations in the bitcoin-backup format. Files are created with 0600 permissions.",
-							},
-							{
-								icon: ShieldCheck,
-								title: "No passphrase env vars",
-								text: "Passphrases are entered through a temporary local web prompt, never read from the environment.",
-							},
-							{
-								icon: Fingerprint,
-								title: "Bitcoin-signed auth",
-								text: "Hosted mode uses OAuth 2.1 via sigma-auth. Your public key is your identity. Nothing to register.",
-							},
-							{
-								icon: Wallet,
-								title: "External signers",
-								text: "Point at a BRC-100 wallet and it stays the permission authority. Every spend is approved there.",
-							},
-						].map(({ icon: Icon, title, text }) => (
-							<li
-								key={title}
-								className="rounded-xl border border-border bg-card/40 p-5"
-							>
-								<Icon className="size-5 text-amber-400" />
-								<h3 className="mt-3 font-semibold">{title}</h3>
-								<p className="mt-1.5 text-sm text-muted-foreground">{text}</p>
+						{guarantees.map(({ icon: Icon, title, description }) => (
+							<li key={title}>
+								<Card className="h-full bg-card/60">
+									<CardHeader>
+										<Icon className="size-5 text-primary" />
+										<CardTitle className="pt-2">{title}</CardTitle>
+										<CardDescription>{description}</CardDescription>
+									</CardHeader>
+								</Card>
 							</li>
 						))}
 					</ul>
 				</div>
 			</section>
 
-			{/* CTA */}
 			<section className="mx-auto max-w-6xl px-6 pb-24">
-				<div className="relative overflow-hidden rounded-2xl border border-amber-500/30 bg-gradient-to-br from-amber-500/15 via-card to-card p-10 text-center">
-					<h2 className="text-3xl font-bold tracking-tight">
-						Put your agent on-chain
-					</h2>
-					<p className="mx-auto mt-3 max-w-xl text-muted-foreground">
-						Generate a key, download the backup, paste the config. You'll be
-						sending a transaction from a chat window in under two minutes.
-					</p>
-					<div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
-						<Link
-							href="/connect"
-							className="inline-flex items-center justify-center gap-2 rounded-md bg-amber-500 px-5 py-2.5 text-sm font-semibold text-black hover:bg-amber-400"
-						>
-							Get started <ArrowRight className="size-4" />
-						</Link>
-						<a
-							href={GITHUB_URL}
-							target="_blank"
-							rel="noreferrer"
-							className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-background/60 px-5 py-2.5 text-sm font-medium hover:bg-accent"
-						>
-							<Github className="size-4" /> Star on GitHub
-						</a>
-					</div>
-				</div>
+				<Card className="overflow-hidden border-primary/30 bg-gradient-to-br from-primary/15 via-card to-card text-center">
+					<CardHeader className="items-center gap-3 p-10">
+						<CardTitle className="text-3xl font-bold tracking-tight">
+							Put your agent on-chain
+						</CardTitle>
+						<CardDescription className="mx-auto max-w-xl text-base">
+							Generate a key, download the backup, paste the config. You&apos;ll
+							be sending a transaction from a chat window in under two minutes.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="flex flex-col justify-center gap-3 pb-10 sm:flex-row">
+						<Button size="xl" asChild>
+							<Link href="/connect">
+								Get started
+								<ArrowRight />
+							</Link>
+						</Button>
+						<Button size="xl" variant="outline" asChild>
+							<a href={GITHUB_URL} target="_blank" rel="noreferrer">
+								<Github />
+								Star on GitHub
+							</a>
+						</Button>
+					</CardContent>
+				</Card>
 			</section>
 
-			{/* Footer */}
-			<footer className="border-t border-border">
+			<footer className="border-t">
 				<div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-8 text-sm text-muted-foreground">
 					<p>© {new Date().getFullYear()} BSV MCP · MIT License</p>
-					<div className="flex gap-6">
+					<div className="flex flex-wrap gap-6">
 						<a
 							href={GITHUB_URL}
 							target="_blank"

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -18,7 +18,27 @@
 	--color-popover-foreground: hsl(var(--popover-foreground));
 	--color-card: hsl(var(--card));
 	--color-card-foreground: hsl(var(--card-foreground));
+	--color-success: hsl(var(--success));
+	--color-success-foreground: hsl(var(--success-foreground));
+	--color-warning: hsl(var(--warning));
+	--color-warning-foreground: hsl(var(--warning-foreground));
 
+	--color-chart-1: hsl(var(--chart-1));
+	--color-chart-2: hsl(var(--chart-2));
+	--color-chart-3: hsl(var(--chart-3));
+	--color-chart-4: hsl(var(--chart-4));
+	--color-chart-5: hsl(var(--chart-5));
+
+	--color-sidebar: hsl(var(--sidebar));
+	--color-sidebar-foreground: hsl(var(--sidebar-foreground));
+	--color-sidebar-primary: hsl(var(--sidebar-primary));
+	--color-sidebar-primary-foreground: hsl(var(--sidebar-primary-foreground));
+	--color-sidebar-accent: hsl(var(--sidebar-accent));
+	--color-sidebar-accent-foreground: hsl(var(--sidebar-accent-foreground));
+	--color-sidebar-border: hsl(var(--sidebar-border));
+	--color-sidebar-ring: hsl(var(--sidebar-ring));
+
+	--radius-xl: calc(var(--radius) + 4px);
 	--radius-lg: var(--radius);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-sm: calc(var(--radius) - 4px);

--- a/components/landing/CodeSnippet.tsx
+++ b/components/landing/CodeSnippet.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+
+interface CodeSnippetProps {
+	code: string;
+	className?: string;
+}
+
+export function CodeSnippet({ code, className }: CodeSnippetProps) {
+	return (
+		<pre
+			className={cn(
+				"overflow-x-auto rounded-lg border bg-muted/40 p-4 font-mono text-xs leading-relaxed text-foreground",
+				className,
+			)}
+		>
+			<code>{code}</code>
+		</pre>
+	);
+}

--- a/components/landing/CopyCommand.tsx
+++ b/components/landing/CopyCommand.tsx
@@ -2,6 +2,7 @@
 
 import { Check, Copy } from "lucide-react";
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface CopyCommandProps {
@@ -25,26 +26,29 @@ export function CopyCommand({ command, className }: CopyCommandProps) {
 	return (
 		<div
 			className={cn(
-				"group flex items-center gap-3 rounded-lg border border-border bg-black/40 pl-4 pr-2 py-2 font-mono text-sm",
+				"flex items-center gap-3 rounded-lg border bg-muted/40 py-2 pl-4 pr-2 font-mono text-sm",
 				className,
 			)}
 		>
-			<span className="select-none text-amber-400">$</span>
+			<span aria-hidden className="select-none text-primary">
+				$
+			</span>
 			<code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-foreground">
 				{command}
 			</code>
-			<button
+			<Button
 				type="button"
+				variant="ghost"
+				size="icon"
 				onClick={copy}
-				aria-label="Copy command"
-				className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+				aria-label={copied ? "Command copied" : "Copy command"}
 			>
 				{copied ? (
-					<Check className="size-4 text-emerald-400" />
+					<Check className="text-success" />
 				) : (
-					<Copy className="size-4" />
+					<Copy className="text-muted-foreground" />
 				)}
-			</button>
+			</Button>
 		</div>
 	);
 }

--- a/components/landing/CopyCommand.tsx
+++ b/components/landing/CopyCommand.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface CopyCommandProps {
+	command: string;
+	className?: string;
+}
+
+export function CopyCommand({ command, className }: CopyCommandProps) {
+	const [copied, setCopied] = useState(false);
+
+	async function copy() {
+		try {
+			await navigator.clipboard.writeText(command);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			// Clipboard unavailable (insecure context); nothing to do.
+		}
+	}
+
+	return (
+		<div
+			className={cn(
+				"group flex items-center gap-3 rounded-lg border border-border bg-black/40 pl-4 pr-2 py-2 font-mono text-sm",
+				className,
+			)}
+		>
+			<span className="select-none text-amber-400">$</span>
+			<code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-foreground">
+				{command}
+			</code>
+			<button
+				type="button"
+				onClick={copy}
+				aria-label="Copy command"
+				className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+			>
+				{copied ? (
+					<Check className="size-4 text-emerald-400" />
+				) : (
+					<Copy className="size-4" />
+				)}
+			</button>
+		</div>
+	);
+}

--- a/components/landing/TerminalDemo.tsx
+++ b/components/landing/TerminalDemo.tsx
@@ -1,0 +1,51 @@
+import { Card } from "@/components/ui/card";
+
+const trafficLights = ["bg-chart-3", "bg-chart-1", "bg-chart-2"];
+
+export function TerminalDemo() {
+	return (
+		<Card className="min-w-0 overflow-hidden bg-card/80 py-0 shadow-2xl">
+			<div className="flex items-center gap-2 border-b px-4 py-2.5">
+				{trafficLights.map((color) => (
+					<span
+						key={color}
+						aria-hidden
+						className={`size-2.5 rounded-full opacity-70 ${color}`}
+					/>
+				))}
+				<span className="ml-2 font-mono text-xs text-muted-foreground">
+					claude
+				</span>
+			</div>
+			<div className="space-y-4 break-words p-5 font-mono text-[13px] leading-relaxed">
+				<p>
+					<span className="text-primary">&gt; </span>
+					<span className="text-foreground">
+						inscribe hello.svg as a 1sat ordinal and tell me the txid
+					</span>
+				</p>
+				<div className="space-y-1 text-muted-foreground">
+					<p>
+						<span className="text-success">●</span> wallet_createOrdinals(file:
+						&quot;hello.svg&quot;, contentType: &quot;image/svg+xml&quot;)
+					</p>
+					<p className="pl-4 text-muted-foreground/70">
+						├ reading file (412 bytes)
+					</p>
+					<p className="pl-4 text-muted-foreground/70">
+						├ selecting UTXOs · fee 1 sat/kb
+					</p>
+					<p className="pl-4 text-muted-foreground/70">└ broadcast ✓</p>
+				</div>
+				<p className="text-foreground">
+					Inscribed. Outpoint <span className="text-primary">f3a1…9c2e_0</span>{" "}
+					— view it on{" "}
+					<span className="underline decoration-muted-foreground/40">
+						1satordinals.com
+					</span>
+					.
+				</p>
+			</div>
+		</Card>
+	);
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,34 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+	"inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+	{
+		variants: {
+			variant: {
+				default: "border-transparent bg-primary text-primary-foreground shadow",
+				secondary: "border-transparent bg-secondary text-secondary-foreground",
+				destructive:
+					"border-transparent bg-destructive text-destructive-foreground shadow",
+				outline: "border-border bg-card/60 text-muted-foreground",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+export interface BadgeProps
+	extends HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+	return (
+		<div className={cn(badgeVariants({ variant }), className)} {...props} />
+	);
+}
+
+export { Badge, badgeVariants };

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -22,6 +22,7 @@ const buttonVariants = cva(
 			},
 			size: {
 				default: "h-9 px-4 py-2",
+				xl: "h-11 rounded-md px-6 text-sm",
 				sm: "h-8 rounded-md px-3 text-xs",
 				lg: "h-10 rounded-md px-8",
 				icon: "h-9 w-9",

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import {
+	type ComponentPropsWithoutRef,
+	type ElementRef,
+	forwardRef,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+const Separator = forwardRef<
+	ElementRef<typeof SeparatorPrimitive.Root>,
+	ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+	(
+		{ className, orientation = "horizontal", decorative = true, ...props },
+		ref,
+	) => (
+		<SeparatorPrimitive.Root
+			ref={ref}
+			decorative={decorative}
+			orientation={orientation}
+			className={cn(
+				"shrink-0 bg-border",
+				orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+				className,
+			)}
+			{...props}
+		/>
+	),
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/lib/tool-count.test.ts
+++ b/lib/tool-count.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { approximateTotal, countTools, getToolCounts } from "./tool-count";
+
+describe("getToolCounts", () => {
+	const counts = getToolCounts();
+
+	test("finds registrations in every shipped category", () => {
+		// Guards the registration regex: if the MCP registration API changes and
+		// this scan stops matching, the landing page would quietly claim zero
+		// tools rather than failing here.
+		for (const dir of ["wallet", "bsv", "ordinals", "bap", "bsocial", "mnee"]) {
+			expect(counts.byDirectory[dir]).toBeGreaterThan(0);
+		}
+	});
+
+	test("totals only the categories enabled by default", () => {
+		const summed = Object.entries(counts.byDirectory)
+			.filter(([dir]) => dir !== "a2b")
+			.reduce((total, [, count]) => total + count, 0);
+
+		expect(counts.total).toBe(summed);
+		expect(counts.total).toBeGreaterThan(50);
+	});
+
+	test("ignores test files", () => {
+		// tools/bap has three sources but only one registers tools per file;
+		// its *.test.ts neighbours must not inflate the count.
+		expect(counts.byDirectory.bap).toBeLessThan(10);
+	});
+});
+
+describe("countTools", () => {
+	const counts = getToolCounts();
+
+	test("sums the requested directories", () => {
+		expect(countTools(counts, ["mnee", "utils"])).toBe(
+			(counts.byDirectory.mnee ?? 0) + (counts.byDirectory.utils ?? 0),
+		);
+	});
+
+	test("ignores unknown directories", () => {
+		expect(countTools(counts, ["does-not-exist"])).toBe(0);
+	});
+});
+
+describe("approximateTotal", () => {
+	test("floors to the nearest bucket", () => {
+		expect(approximateTotal(91)).toBe("90+");
+		expect(approximateTotal(90)).toBe("90+");
+		expect(approximateTotal(99)).toBe("90+");
+	});
+
+	test("returns null below one bucket", () => {
+		expect(approximateTotal(0)).toBeNull();
+		expect(approximateTotal(9)).toBeNull();
+	});
+});

--- a/lib/tool-count.ts
+++ b/lib/tool-count.ts
@@ -1,0 +1,89 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Counts the MCP tools this server registers by reading the `tools/` sources.
+ *
+ * The landing page renders these numbers, so the copy tracks the codebase
+ * instead of a hand-maintained figure that drifts as tools are added.
+ * Everything here runs at build time in a server component.
+ */
+
+const TOOLS_DIR = join(process.cwd(), "tools");
+
+/** Matches `server.tool(` and `server.registerTool(`, the two registration calls. */
+const REGISTRATION = /\bserver\s*\.\s*(?:registerTool|tool)\s*\(/g;
+
+/** Categories that are not registered by default, so they stay out of the totals. */
+const DEFAULT_DISABLED = new Set(["a2b"]);
+
+function collectSourceFiles(dir: string): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...collectSourceFiles(path));
+		} else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+			files.push(path);
+		}
+	}
+	return files;
+}
+
+function countRegistrations(dir: string): number {
+	return collectSourceFiles(dir).reduce((total, file) => {
+		const matches = readFileSync(file, "utf8").match(REGISTRATION);
+		return total + (matches?.length ?? 0);
+	}, 0);
+}
+
+export interface ToolCounts {
+	/** Tools registered by default, summed across every enabled category. */
+	total: number;
+	/** Registered tools keyed by their `tools/` directory name. */
+	byDirectory: Record<string, number>;
+}
+
+let cached: ToolCounts | null = null;
+
+export function getToolCounts(): ToolCounts {
+	if (cached) return cached;
+
+	const byDirectory: Record<string, number> = {};
+	let total = 0;
+
+	try {
+		for (const entry of readdirSync(TOOLS_DIR, { withFileTypes: true })) {
+			if (!entry.isDirectory()) continue;
+			const count = countRegistrations(join(TOOLS_DIR, entry.name));
+			byDirectory[entry.name] = count;
+			if (!DEFAULT_DISABLED.has(entry.name)) total += count;
+		}
+	} catch {
+		// Sources unavailable (for example a deploy that ships only the app).
+		// Callers fall back to copy that carries no number.
+	}
+
+	cached = { total, byDirectory };
+	return cached;
+}
+
+/** Sums the tools in the given `tools/` directories, ignoring unknown names. */
+export function countTools(
+	counts: ToolCounts,
+	directories: readonly string[],
+): number {
+	return directories.reduce(
+		(total, dir) => total + (counts.byDirectory[dir] ?? 0),
+		0,
+	);
+}
+
+/**
+ * Renders a total as an approximate floor, so the headline reads "90+" rather
+ * than a precise figure that invites nitpicking. Returns null below one bucket.
+ */
+export function approximateTotal(total: number, bucket = 10): string | null {
+	const floored = Math.floor(total / bucket) * bucket;
+	return floored >= bucket ? `${floored}+` : null;
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+	plugins: {
+		"@tailwindcss/postcss": {},
+	},
+};
+
+export default config;


### PR DESCRIPTION
## Summary

bsvmcp.com had no landing page, and more importantly it was rendering with no CSS at all. The repo was missing `postcss.config.mjs`, so Next.js never compiled Tailwind v4 and every route, including the existing onboarding flow, fell back to unstyled browser defaults. That one file fixes the whole site.

On top of that fix, this adds a real landing page at `/`, moves the key onboarding flow to `/connect`, and routes the whole site through shadcn/ui primitives and theme variables.

## Changes

**Tailwind build**
- Add `postcss.config.mjs` registering `@tailwindcss/postcss`. Without it no Tailwind output was emitted.

**Landing page**
- New marketing page at `/`: hero with a terminal demo, copyable install command, supported clients, a three-step overview, tool category cards, deployment modes with config snippets, a key-custody section, and a CTA.
- Onboarding moves from `/` to `/connect`. The existing `/auth` redirect now points there.
- Site metadata now describes the product rather than the hosted service.

**Theme and components**
- `app/globals.css` carries the standard shadcn token set for light and dark: the base scale plus `success`, `warning`, `chart-1..5`, and the full `sidebar-*` scale. Every token is mapped in the Tailwind `@theme` block.
- Brand amber is now `--primary` rather than a hardcoded `amber-500`, so retheming is a one-variable edit.
- Add `Badge` and `Separator` primitives and an `xl` `Button` size.
- The page is built from `Card`, `Badge`, `Button` (`asChild`) and `Separator`, with no color literals in the markup. The hero glow and grid overlay read from `hsl(var(--primary))` and `hsl(var(--border))`.

**Tool count is derived, not hardcoded**
- `lib/tool-count.ts` scans `tools/` at build time and counts registration calls per category, skipping test files and the `a2b` category that is disabled by default.
- The hero renders an approximate floor ("90+ tools") and each category card shows its own live count, so the copy tracks the codebase instead of drifting.
- If the sources are unreadable the count is zero, the hero drops the number, and the badges are omitted rather than rendering "0 tools".

## Testing

- `bun run build:next` compiles; `/` remains statically prerendered.
- `bun test lib/tool-count.test.ts`: 7 tests covering per-category detection, the enabled-category total, and the rounding. These guard the registration regex so a future MCP API change fails loudly instead of silently rendering zero tools.
- Biome clean on all touched files. Note that `bun run lint` still reports pre-existing import-ordering issues in four `tools/` and `utils/` files untouched by this PR.
- Verified visually from a production build at 1280px and 390px, plus `/connect`. No horizontal overflow on mobile.

## Note for reviewers

Because `--primary` is now amber, the disabled "Create Session" button on `/connect` renders as amber at 50% opacity, which reads as brown. That is stock shadcn disabled styling rather than a bug, but a muted disabled state may be preferable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG

---
_Generated by [Claude Code](https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791320963&installation_model_id=435537&pr_number=11&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F11&signature=b910eb8ad322c19fe4b0f86fa7ad11a21e0e6dbe0f0ac1ce3437a993b708d8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->