### PR TITLE
Add per-client install tabs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 import {
 	ArrowRight,
 	Bitcoin,
-	Blocks,
 	Cloud,
 	Fingerprint,
 	Github,
@@ -14,11 +13,10 @@ import {
 	ShieldCheck,
 	Terminal,
 	Wallet,
-	Wrench,
 } from "lucide-react";
 import Link from "next/link";
-import { CodeSnippet } from "@/components/landing/CodeSnippet";
 import { CopyCommand } from "@/components/landing/CopyCommand";
+import { InstallTabs } from "@/components/landing/InstallTabs";
 import { TerminalDemo } from "@/components/landing/TerminalDemo";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -37,11 +35,11 @@ import {
 	NPM_URL,
 } from "@/lib/site";
 import {
-	clientConfig,
 	clients,
 	deployModes,
 	guarantees,
 	installCommands,
+	installTargets,
 	steps,
 	toolCategories,
 } from "@/lib/site-content";
@@ -283,26 +281,12 @@ export default function LandingPage() {
 
 					<Separator className="my-10" />
 
-					<div className="grid gap-6 lg:grid-cols-2">
-						<div className="space-y-3">
-							<p className="flex items-center gap-2 text-sm font-medium">
-								<Plug className="size-4 text-primary" />
-								Claude Code
-							</p>
-							<CopyCommand command={installCommands.claudeCode} />
-							<p className="flex items-center gap-2 pt-2 text-sm font-medium">
-								<Wrench className="size-4 text-primary" />
-								Any stdio client
-							</p>
-							<CopyCommand command={installCommands.stdio} />
-						</div>
-						<div className="space-y-3">
-							<p className="flex items-center gap-2 text-sm font-medium">
-								<Blocks className="size-4 text-primary" />
-								Cursor / Claude Desktop
-							</p>
-							<CodeSnippet code={clientConfig} />
-						</div>
+					<div className="space-y-4">
+						<p className="flex items-center gap-2 text-sm font-medium">
+							<Plug className="size-4 text-primary" />
+							Pick your client
+						</p>
+						<InstallTabs targets={installTargets} />
 					</div>
 				</div>
 			</section>

--- a/components/landing/InstallTabs.tsx
+++ b/components/landing/InstallTabs.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { InstallTarget } from "@/lib/site-content";
+import { CodeSnippet } from "./CodeSnippet";
+import { CopyCommand } from "./CopyCommand";
+
+interface InstallTabsProps {
+	targets: InstallTarget[];
+}
+
+/**
+ * Per-client install instructions.
+ *
+ * Every tab is generated from `installTargets`, so adding a client is a data
+ * change and the docs link always matches the snippet shown.
+ */
+export function InstallTabs({ targets }: InstallTabsProps) {
+	const first = targets[0];
+	if (!first) return null;
+
+	return (
+		<Tabs defaultValue={first.key} className="w-full">
+			<TabsList className="flex h-auto w-full flex-wrap justify-start gap-1">
+				{targets.map((target) => (
+					<TabsTrigger key={target.key} value={target.key}>
+						{target.label}
+					</TabsTrigger>
+				))}
+			</TabsList>
+
+			{targets.map((target) => (
+				<TabsContent
+					key={target.key}
+					value={target.key}
+					className="space-y-3 pt-4"
+				>
+					{target.command ? <CopyCommand command={target.command} /> : null}
+
+					{target.config ? (
+						<div className="space-y-2">
+							{target.configPath ? (
+								<p className="font-mono text-xs text-muted-foreground">
+									{target.configPath}
+								</p>
+							) : null}
+							<CodeSnippet code={target.config} />
+						</div>
+					) : null}
+
+					{target.note ? (
+						<p className="text-sm text-muted-foreground">{target.note}</p>
+					) : null}
+
+					<Button variant="link" asChild className="h-auto px-0">
+						<a href={target.docsUrl} target="_blank" rel="noreferrer">
+							{target.label} MCP documentation
+							<ExternalLink />
+						</a>
+					</Button>
+				</TabsContent>
+			))}
+		</Tabs>
+	);
+}

--- a/lib/install-targets.test.ts
+++ b/lib/install-targets.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { renderHomeMarkdown } from "./markdown";
+import { installTargets } from "./site-content";
+
+describe("installTargets", () => {
+	test("keys and labels are unique", () => {
+		const keys = installTargets.map((t) => t.key);
+		const labels = installTargets.map((t) => t.label);
+		expect(new Set(keys).size).toBe(keys.length);
+		expect(new Set(labels).size).toBe(labels.length);
+	});
+
+	test("every target carries instructions and an official docs link", () => {
+		for (const target of installTargets) {
+			const hasInstructions = Boolean(target.command || target.config);
+			expect(hasInstructions).toBe(true);
+			expect(target.docsUrl.startsWith("https://")).toBe(true);
+		}
+	});
+
+	test("a config always says where it belongs", () => {
+		for (const target of installTargets) {
+			if (target.config) expect(target.configPath).toBeTruthy();
+		}
+	});
+
+	test("TOML clients get TOML and JSON clients get JSON", () => {
+		for (const target of installTargets) {
+			if (!target.config || !target.configPath) continue;
+			if (target.configPath.endsWith(".toml")) {
+				expect(target.config).toContain("[mcp_servers.");
+				expect(target.config.trimStart().startsWith("{")).toBe(false);
+			}
+			if (target.configPath.endsWith(".json")) {
+				expect(() => JSON.parse(target.config as string)).not.toThrow();
+			}
+		}
+	});
+
+	test("omits clients without verified MCP support", () => {
+		// pi has no MCP support by design, so it must not appear with invented
+		// configuration. See lib/site-content.ts for the rationale.
+		const keys = installTargets.map((t) => t.key);
+		expect(keys).not.toContain("pi");
+	});
+
+	test("every documented client reaches the markdown docs", () => {
+		const doc = renderHomeMarkdown();
+		for (const target of installTargets) {
+			expect(doc).toContain(`### ${target.label}`);
+			expect(doc).toContain(target.docsUrl);
+		}
+	});
+});

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -13,11 +13,11 @@ import {
 	SITE_URL,
 } from "./site";
 import {
-	clientConfig,
 	clients,
 	deployModes,
 	guarantees,
 	installCommands,
+	installTargets,
 	steps,
 	toolCategories,
 } from "./site-content";
@@ -32,6 +32,31 @@ function scopeList(): string {
 	return OAUTH_SCOPES.map(
 		(scope) => `- \`${scope.name}\` — ${scope.description}`,
 	).join("\n");
+}
+
+/** Renders every documented client's install instructions. */
+function renderInstallTargets(): string {
+	return installTargets
+		.map((target) => {
+			const parts: string[] = [`### ${target.label}`];
+
+			if (target.command) {
+				parts.push(`\`\`\`bash\n${target.command}\n\`\`\``);
+			}
+			for (const alt of target.altCommands ?? []) {
+				parts.push(`${alt.label}:\n\n\`\`\`bash\n${alt.command}\n\`\`\``);
+			}
+			if (target.config) {
+				const language = target.configPath?.endsWith(".toml") ? "toml" : "json";
+				if (target.configPath) parts.push(`\`${target.configPath}\`:`);
+				parts.push(`\`\`\`${language}\n${target.config}\n\`\`\``);
+			}
+			if (target.note) parts.push(target.note);
+			parts.push(`Docs: ${target.docsUrl}`);
+
+			return parts.join("\n\n");
+		})
+		.join("\n\n");
 }
 
 export function renderHomeMarkdown(): string {
@@ -58,23 +83,7 @@ export function renderHomeMarkdown(): string {
 
 ## Install
 
-Claude Code:
-
-\`\`\`bash
-${installCommands.claudeCode}
-\`\`\`
-
-Any stdio client:
-
-\`\`\`bash
-${installCommands.stdio}
-\`\`\`
-
-Cursor or Claude Desktop:
-
-\`\`\`json
-${clientConfig}
-\`\`\`
+${renderInstallTargets()}
 
 Works with ${clients.join(", ")}.
 

--- a/lib/site-content.ts
+++ b/lib/site-content.ts
@@ -131,7 +131,9 @@ export const clients = [
 	"Claude Code",
 	"Claude Desktop",
 	"Cursor",
-	"Windsurf",
+	"Codex",
+	"Grok Build",
+	"opencode",
 	"Any MCP client",
 ];
 
@@ -148,3 +150,130 @@ export const clientConfig = `{
     }
   }
 }`;
+
+export interface InstallCommand {
+	label: string;
+	command: string;
+}
+
+export interface InstallTarget {
+	key: string;
+	label: string;
+	/** Primary shell command, when the client has a CLI. */
+	command?: string;
+	/** Further commands for the same client, each with its own label. */
+	altCommands?: InstallCommand[];
+	/** Where the config below belongs on disk. */
+	configPath?: string;
+	config?: string;
+	note?: string;
+	docsUrl: string;
+}
+
+const STDIO_JSON = `{
+  "mcpServers": {
+    "bsv-mcp": {
+      "command": "bunx",
+      "args": ["bsv-mcp@latest"]
+    }
+  }
+}`;
+
+const STDIO_TOML = `[mcp_servers.bsv-mcp]
+command = "bunx"
+args = ["bsv-mcp@latest"]`;
+
+/**
+ * Per-client install instructions.
+ *
+ * Every entry comes from that client's official MCP documentation. Clients
+ * whose syntax could not be verified are deliberately absent rather than
+ * guessed: pi is omitted because it has no MCP support by design, and Claude
+ * Desktop shows only the local form because its documented config file covers
+ * local servers, with remote servers added through its Connectors UI.
+ */
+export const installTargets: InstallTarget[] = [
+	{
+		key: "claude-code",
+		label: "Claude Code",
+		command: "claude plugin install bsv-mcp@b-open-io",
+		altCommands: [
+			{
+				label: "Or register the local server yourself",
+				command:
+					"claude mcp add --transport stdio bsv-mcp -- bunx bsv-mcp@latest",
+			},
+			{
+				label: "Or use the hosted server",
+				command:
+					"claude mcp add --transport http bsv-mcp https://bsvmcp.com/api/mcp",
+			},
+		],
+		note: "The plugin bundles the server and registers it automatically, so no config file is needed.",
+		docsUrl: "https://code.claude.com/docs/en/mcp",
+	},
+	{
+		key: "claude-desktop",
+		label: "Claude Desktop",
+		configPath:
+			"~/Library/Application Support/Claude/claude_desktop_config.json",
+		config: STDIO_JSON,
+		note: "Restart Claude Desktop after editing. On Windows the file lives under %APPDATA%\\Claude. Remote servers are added through the Connectors UI rather than this file.",
+		docsUrl:
+			"https://modelcontextprotocol.io/docs/develop/connect-local-servers",
+	},
+	{
+		key: "cursor",
+		label: "Cursor",
+		configPath: ".cursor/mcp.json",
+		config: STDIO_JSON,
+		docsUrl: "https://docs.cursor.com/context/model-context-protocol",
+	},
+	{
+		key: "codex",
+		label: "Codex",
+		command: "codex mcp add bsv-mcp -- bunx bsv-mcp@latest",
+		configPath: "~/.codex/config.toml",
+		config: STDIO_TOML,
+		note: "The command and the config file are equivalent. Codex reads TOML, not JSON.",
+		docsUrl: "https://learn.chatgpt.com/docs/extend/mcp?surface=cli",
+	},
+	{
+		key: "grok",
+		label: "Grok Build",
+		command: "grok mcp add bsv-mcp -- bunx bsv-mcp@latest",
+		altCommands: [
+			{
+				label: "Or use the hosted server",
+				command:
+					"grok mcp add --transport http bsv-mcp https://bsvmcp.com/api/mcp",
+			},
+		],
+		configPath: "~/.grok/config.toml",
+		config: STDIO_TOML,
+		docsUrl: "https://docs.x.ai/build/features/mcp-servers",
+	},
+	{
+		key: "opencode",
+		label: "opencode",
+		configPath: "opencode.json",
+		config: `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "bsv-mcp": {
+      "type": "local",
+      "command": ["bunx", "bsv-mcp@latest"],
+      "enabled": true
+    }
+  }
+}`,
+		docsUrl: "https://opencode.ai/docs/mcp-servers/",
+	},
+	{
+		key: "other",
+		label: "Any MCP client",
+		command: "bunx bsv-mcp@latest",
+		note: "Any client that speaks MCP over stdio can run the server directly. For Streamable HTTP, point it at https://bsvmcp.com/api/mcp and authenticate with OAuth 2.1.",
+		docsUrl: "https://modelcontextprotocol.io",
+	},
+];


### PR DESCRIPTION
## Summary

Replaces the two-column install block with tabs, one per client: Claude Code, Claude Desktop, Cursor, Codex, Grok Build, opencode, and a generic stdio client. Each tab carries the CLI command where one exists, the config file with its path on disk, and a link to that client's official MCP documentation.

The tabs render from `lib/site-content.ts`, and the markdown documents render the same data, so the page and the docs cannot drift.

## Accuracy

Every snippet comes from the client's own documentation. Two deliberate omissions, both covered by tests so they cannot be casually undone:

- **pi** has no MCP support. Its own site says so explicitly: it uses Skills instead, and suggests building an extension if you want MCP. A third-party adapter exists, but publishing it as if it were supported would be misleading, so pi is absent rather than guessed at.
- **Claude Desktop** shows only the local stdio form, because its documented config file covers local servers. Remote servers are added through the Connectors UI, and I could not verify a remote-URL syntax for that file.

Note that Codex and Grok Build take TOML, not JSON. A test asserts that `.toml` paths get TOML and `.json` paths parse as JSON, so a future edit cannot quietly put the wrong format under the wrong client.

## On the component library

You asked for **brainless**, and it does exist: a shadcn registry by theswerd that recreates the terminal UIs of Claude Code, Codex and Grok. It does not contain a tabbed code block. I pulled its registry index and all 39 items are agent-terminal UI pieces, with no snippet, code-block or tabs component.

The library that does have this is **Kibo UI**, whose `snippet` component is described as a tabbed code block and is the usual choice for package-manager install tabs. I did not add it, because the repo already has the shadcn `tabs` primitive and reusing it keeps the design consistent with no new registry dependency. Happy to swap to Kibo's `snippet` if you prefer it, and brainless would be a good fit for the hero terminal mock, which is currently hand-rolled.

## Testing

43 unit tests pass, 6 new: unique keys and labels, every target has instructions and an official docs link, any config states where it belongs, TOML and JSON land under the right clients, pi stays absent, and every documented client reaches the markdown docs.

Verified on the preview deployment that all seven tabs render, tab switching shows the right snippet, the Codex TOML appears, the markdown variant carries the same sections, and there is no horizontal overflow at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG

---
_Generated by [Claude Code](https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791323582&installation_model_id=435537&pr_number=14&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F14&signature=c0d2bc410fc7157db639b124d5088d7194b4b9ebb83d18a96fe6ebf6815294d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->