### PR TITLE
Serve RFC 9728 metadata at the path MCP clients request

### DIFF
--- a/app/.well-known/oauth-protected-resource/[...path]/route.ts
+++ b/app/.well-known/oauth-protected-resource/[...path]/route.ts
@@ -1,0 +1,45 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+	MCP_RESOURCE_PATH,
+	METADATA_CORS_HEADERS,
+	METADATA_HEADERS,
+	protectedResourceMetadata,
+} from "@/lib/oauth-metadata";
+
+/**
+ * RFC 9728 §3.1 metadata for a resource that lives under a path.
+ *
+ * For the resource `https://host/api/mcp`, clients insert the resource path
+ * into the well-known URL and request
+ * `https://host/.well-known/oauth-protected-resource/api/mcp`. Without this
+ * route that request 404s and a client cannot discover the authorization
+ * server, which is where Claude's connector flow stops.
+ */
+export async function GET(
+	request: NextRequest,
+	context: { params: Promise<{ path?: string[] }> },
+) {
+	const { path } = await context.params;
+	const requested = (path ?? []).join("/");
+
+	if (requested !== MCP_RESOURCE_PATH) {
+		return NextResponse.json(
+			{
+				error: "not_found",
+				error_description: `No protected resource is published at /${requested}. This server publishes /${MCP_RESOURCE_PATH}.`,
+			},
+			{ status: 404, headers: METADATA_HEADERS },
+		);
+	}
+
+	return NextResponse.json(protectedResourceMetadata(request.nextUrl.origin), {
+		headers: METADATA_HEADERS,
+	});
+}
+
+export async function OPTIONS() {
+	return new NextResponse(null, {
+		status: 204,
+		headers: METADATA_CORS_HEADERS,
+	});
+}

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,43 +1,26 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { AUTH_SERVER_URL, OAUTH_SCOPE_NAMES, SITE_NAME } from "@/lib/site";
+import {
+	METADATA_CORS_HEADERS,
+	METADATA_HEADERS,
+	protectedResourceMetadata,
+} from "@/lib/oauth-metadata";
 
 /**
- * OAuth 2.0 Protected Resource Metadata (RFC 9728).
+ * RFC 9728 metadata at the bare well-known path.
  *
- * Declaring `scopes_supported` here is what lets an agent request least
- * privilege: without it a client has no machine-readable way to know which
- * scopes this resource understands. The resource identifier is derived from
- * the request origin, so previews and production each describe themselves.
+ * MCP clients following the spec request the path-suffixed form handled by the
+ * sibling catch-all route. This one stays for clients that request the bare
+ * path, and for anything still pointing at the previous location.
  */
-function metadataFor(request: NextRequest) {
-	const origin = request.nextUrl.origin;
-
-	return {
-		resource: origin,
-		authorization_servers: [AUTH_SERVER_URL],
-		scopes_supported: OAUTH_SCOPE_NAMES,
-		bearer_methods_supported: ["header"],
-		resource_name: SITE_NAME,
-		resource_documentation: `${origin}/llms.txt`,
-	};
-}
-
 export async function GET(request: NextRequest) {
-	return NextResponse.json(metadataFor(request), {
-		headers: {
-			"Access-Control-Allow-Origin": "*",
-			"Cache-Control": "public, max-age=3600",
-		},
+	return NextResponse.json(protectedResourceMetadata(request.nextUrl.origin), {
+		headers: METADATA_HEADERS,
 	});
 }
 
 export async function OPTIONS() {
 	return new NextResponse(null, {
 		status: 204,
-		headers: {
-			"Access-Control-Allow-Origin": "*",
-			"Access-Control-Allow-Methods": "GET, OPTIONS",
-			"Access-Control-Allow-Headers": "Content-Type, Authorization",
-		},
+		headers: METADATA_CORS_HEADERS,
 	});
 }

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,6 +1,7 @@
 import { PrivateKey } from "@bsv/sdk";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { createMcpHandler, withMcpAuth } from "mcp-handler";
+import { RESOURCE_METADATA_PATH } from "@/lib/oauth-metadata";
 import { registerAllTools } from "@/tools";
 
 // This Next.js route wraps the BSV MCP server for Vercel deployment
@@ -120,7 +121,10 @@ const handler = createMcpHandler(
 const withAuth = withMcpAuth(handler, verifyToken, {
 	required: process.env.ENABLE_OAUTH !== "false",
 	requiredScopes: [],
-	resourceMetadataPath: "/.well-known/oauth-protected-resource",
+	// RFC 9728 §3.1: the metadata for a resource under a path lives at the
+	// well-known prefix with that path appended. Pointing the challenge at the
+	// bare path sends clients somewhere the spec does not expect.
+	resourceMetadataPath: RESOURCE_METADATA_PATH,
 });
 
 export {

--- a/lib/oauth-metadata.test.ts
+++ b/lib/oauth-metadata.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+	MCP_RESOURCE_PATH,
+	protectedResourceMetadata,
+	RESOURCE_METADATA_PATH,
+} from "./oauth-metadata";
+import { MCP_ENDPOINT, OAUTH_SCOPE_NAMES, SITE_URL } from "./site";
+
+describe("protected resource metadata", () => {
+	const metadata = protectedResourceMetadata(SITE_URL);
+
+	test("identifies the MCP endpoint, not the site origin", () => {
+		// Clients send this exact URI as the RFC 8707 resource parameter.
+		expect(metadata.resource).toBe(MCP_ENDPOINT);
+		expect(metadata.resource).not.toBe(SITE_URL);
+	});
+
+	test("declares scopes and bearer usage", () => {
+		expect(metadata.scopes_supported).toEqual(OAUTH_SCOPE_NAMES);
+		expect(metadata.bearer_methods_supported).toEqual(["header"]);
+	});
+
+	test("names one authorization server", () => {
+		expect(metadata.authorization_servers.length).toBe(1);
+		expect(metadata.authorization_servers[0]?.startsWith("https://")).toBe(
+			true,
+		);
+	});
+
+	test("metadata path follows RFC 9728 path insertion", () => {
+		expect(RESOURCE_METADATA_PATH).toBe(
+			`/.well-known/oauth-protected-resource/${MCP_RESOURCE_PATH}`,
+		);
+		// The resource path must match the endpoint the metadata describes.
+		expect(MCP_ENDPOINT.endsWith(`/${MCP_RESOURCE_PATH}`)).toBe(true);
+	});
+
+	test("uses the caller's origin so previews describe themselves", () => {
+		const preview = protectedResourceMetadata("https://preview.example.com");
+		expect(preview.resource).toBe("https://preview.example.com/api/mcp");
+	});
+});

--- a/lib/oauth-metadata.ts
+++ b/lib/oauth-metadata.ts
@@ -1,0 +1,50 @@
+import { AUTH_SERVER_URL, OAUTH_SCOPE_NAMES, SITE_NAME } from "./site";
+
+/**
+ * OAuth 2.0 Protected Resource Metadata (RFC 9728).
+ *
+ * The resource identifier is the MCP endpoint itself, not the site origin,
+ * because that is the URI clients send as the RFC 8707 `resource` parameter.
+ * RFC 9728 §3.1 then places the metadata at
+ * `/.well-known/oauth-protected-resource/api/mcp`, which is what MCP clients
+ * request; the bare path is still served for older clients.
+ */
+
+/** Path segment of the MCP endpoint, without a leading slash. */
+export const MCP_RESOURCE_PATH = "api/mcp";
+
+/** Where RFC 9728 says this resource's metadata lives. */
+export const RESOURCE_METADATA_PATH = `/.well-known/oauth-protected-resource/${MCP_RESOURCE_PATH}`;
+
+export interface ProtectedResourceMetadata {
+	resource: string;
+	authorization_servers: string[];
+	scopes_supported: string[];
+	bearer_methods_supported: string[];
+	resource_name: string;
+	resource_documentation: string;
+}
+
+export function protectedResourceMetadata(
+	origin: string,
+): ProtectedResourceMetadata {
+	return {
+		resource: `${origin}/${MCP_RESOURCE_PATH}`,
+		authorization_servers: [AUTH_SERVER_URL],
+		scopes_supported: OAUTH_SCOPE_NAMES,
+		bearer_methods_supported: ["header"],
+		resource_name: SITE_NAME,
+		resource_documentation: `${origin}/llms.txt`,
+	};
+}
+
+export const METADATA_HEADERS = {
+	"Access-Control-Allow-Origin": "*",
+	"Cache-Control": "public, max-age=3600",
+} as const;
+
+export const METADATA_CORS_HEADERS = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type, Authorization",
+} as const;


### PR DESCRIPTION
## Summary

Adding the hosted server as a Claude custom connector fails with "Failed to start MCP authorization". I traced the flow request by request. This fixes the parts that are wrong in this repo; the final blocker is in sigma-auth and is described below.

## What was broken here

A client that receives a 401 from `/api/mcp` is meant to fetch the protected-resource metadata at `/.well-known/oauth-protected-resource/api/mcp`. RFC 9728 §3.1 inserts the resource path into the well-known URL. That path returned **404**, and the `WWW-Authenticate` challenge pointed at the bare path instead.

- Added a catch-all route serving the metadata at the path-suffixed URL, with a 404 that explains itself for any other suffix.
- The challenge now points at that URL.
- The resource identifier is the MCP endpoint (`https://bsvmcp.com/api/mcp`) rather than the site origin, since that is the URI clients send as the RFC 8707 `resource` parameter.
- The bare path still answers, for clients that request it.

Metadata construction moved into `lib/oauth-metadata.ts` so the two routes and the challenge path cannot drift.

## What still blocks the connector, outside this repo

Claude registers itself with the authorization server using Dynamic Client Registration. Against sigma-auth that returns:

```
POST https://auth.sigmaidentity.com/api/auth/oauth2/register
401 {"error_description":"Authentication required for client registration"}
```

That is exactly the reported error. The authorization server advertises a `registration_endpoint` in its metadata but refuses unauthenticated registration, so no MCP client can complete the flow on its own. Either:

1. Allow unauthenticated DCR on sigma-auth, which is the self-serve path every MCP client expects, or
2. Pre-register one client with redirect URI `https://claude.ai/api/mcp/auth_callback` and give users its client ID to paste into Claude's connector dialog.

Neither is changeable from this repository.

## Also worth knowing

`mcp.bsvmcp.com` resolves to a Vercel address but has no working certificate, so it fails TLS on every attempt while the apex domain succeeds. The domain is not attached to the project. The working URL is `https://bsvmcp.com/api/mcp`.

## Testing

48 unit tests pass, 5 new: the resource identifies the endpoint rather than the origin, scopes and bearer methods are declared, exactly one authorization server is named, the metadata path follows RFC 9728 insertion and matches the endpoint it describes, and the origin is taken from the caller so previews describe themselves.

Verified locally against a production build: the challenge points at the suffixed URL, both metadata paths return 200 with the endpoint as the resource, and an unrelated suffix returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG

---
_Generated by [Claude Code](https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791323920&installation_model_id=435537&pr_number=15&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F15&signature=9f686b34db4c25bd8953eef1c71dae04f6d0bad129354e6c477ab8501bf46789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->