### PR TITLE
Fix horizontal overflow on the connect page

### DIFF
--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -52,7 +52,7 @@ export default function OnboardingPage() {
 						Model Context Protocol for Bitcoin SV
 					</p>
 					<p className="text-xs text-muted-foreground/60">
-						MCP 2025-03-26 Specification
+						Streamable HTTP · OAuth 2.1
 					</p>
 				</div>
 

--- a/components/onboarding/ConfigTabs.tsx
+++ b/components/onboarding/ConfigTabs.tsx
@@ -216,16 +216,16 @@ export function ConfigTabs({
 				<p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
 					Config File Locations
 				</p>
-				<p className="text-xs text-muted-foreground font-mono">
+				<p className="text-xs text-muted-foreground font-mono break-all">
 					Claude Desktop (macOS):{" "}
 					<span className="text-foreground">
 						~/Library/Application Support/Claude/claude_desktop_config.json
 					</span>
 				</p>
-				<p className="text-xs text-muted-foreground font-mono">
+				<p className="text-xs text-muted-foreground font-mono break-all">
 					Cursor: <span className="text-foreground">~/.cursor/mcp.json</span>
 				</p>
-				<p className="text-xs text-muted-foreground font-mono">
+				<p className="text-xs text-muted-foreground font-mono break-all">
 					VS Code: <span className="text-foreground">~/.vscode/mcp.json</span>
 				</p>
 			</div>

--- a/components/onboarding/KeySetup.tsx
+++ b/components/onboarding/KeySetup.tsx
@@ -29,8 +29,10 @@ export function KeySetup({
 }: KeySetupProps) {
 	return (
 		<div className="space-y-4">
-			{/* Key source selection */}
-			<div className="flex gap-2">
+			{/* Key source selection. Stacks on narrow screens: the buttons carry
+			    whitespace-nowrap, so side by side they cannot shrink below their
+			    label width and overflow the viewport under about 375px. */}
+			<div className="flex flex-col gap-2 sm:flex-row">
 				<Button
 					type="button"
 					variant="outline"


### PR DESCRIPTION
## Summary

The authenticate page scrolled sideways on a phone. I measured every element against the viewport at a range of widths rather than guessing, and found two separate causes.

**The key-source buttons.** "Generate New Key" and "Import Backup" sat in one flex row. The button component carries `whitespace-nowrap`, and flex items default to `min-width: auto`, so neither could shrink below its label width. "Import Backup" extended to 382px regardless of viewport, overflowing at 375px and below. They now stack until the `sm` breakpoint and sit side by side above it.

**The config path.** `~/Library/Application Support/Claude/claude_desktop_config.json` is one long unbreakable token in the post-auth tabs and overflowed at 320px. Those paths can now wrap mid-token.

## Also

The connect header still read "MCP 2025-03-26 Specification". That is the same stale protocol revision already removed from the home page in #12, and the identical source of confusion. It now names the transport and auth instead, which cannot go out of date.

## Verification

Measured before and after at 430, 393, 390, 375, 360 and 320 pixels, on the authenticate view and on each of the four config tabs. Every width now reports document `scrollWidth` equal to the viewport with no element extending past it.

Before:

| Width | scrollWidth | Overflowing element |
|---|---|---|
| 390 | 390 | none |
| 375 | 382 | Import Backup |
| 320 | 382 | Import Backup, config path |

After, every width from 430 down to 320 reports no overflow.

The remaining wide element inside the multiline code blocks is the `<code>` within a `<pre overflow-x-auto>`, which scrolls inside its own container by design and does not move the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG

---
_Generated by [Claude Code](https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791324835&installation_model_id=435537&pr_number=16&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F16&signature=61e9acebfd56190315620c328440f335235aacb23e92ea66a92801f2e070a36c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->