### PR TITLE
Serve the MCP endpoint at the site root

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -3,6 +3,7 @@ import {
 	GITHUB_URL,
 	getAppVersion,
 	MCP_ENDPOINT,
+	MCP_ENDPOINT_LEGACY,
 	MCP_PROTOCOL_LATEST,
 	MCP_PROTOCOL_SUPPORTED,
 	NPM_URL,
@@ -77,7 +78,7 @@ export function renderHomeMarkdown(): string {
 
 - Version: ${getAppVersion()}
 - MCP protocol: ${MCP_PROTOCOL_LATEST} (also accepts ${MCP_PROTOCOL_SUPPORTED.join(", ")})
-- Hosted MCP endpoint: ${MCP_ENDPOINT} (Streamable HTTP, OAuth 2.1)
+- Hosted MCP endpoint: ${MCP_ENDPOINT} (Streamable HTTP, OAuth 2.1; ${MCP_ENDPOINT_LEGACY} also answers)
 - Source: ${GITHUB_URL}
 - Package: ${NPM_URL}
 

--- a/lib/mcp-request.test.ts
+++ b/lib/mcp-request.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { isMcpRequest } from "./mcp-request";
+
+function headers(init: Record<string, string>): Headers {
+	return new Headers(init);
+}
+
+describe("isMcpRequest", () => {
+	test("recognises a JSON-RPC POST", () => {
+		expect(
+			isMcpRequest("POST", headers({ "content-type": "application/json" })),
+		).toBe(true);
+	});
+
+	test("recognises the streamable HTTP accept header", () => {
+		expect(
+			isMcpRequest(
+				"POST",
+				headers({ accept: "application/json, text/event-stream" }),
+			),
+		).toBe(true);
+		expect(isMcpRequest("GET", headers({ accept: "text/event-stream" }))).toBe(
+			true,
+		);
+	});
+
+	test("recognises MCP session and protocol headers", () => {
+		expect(isMcpRequest("GET", headers({ "mcp-session-id": "abc" }))).toBe(
+			true,
+		);
+		expect(
+			isMcpRequest("GET", headers({ "mcp-protocol-version": "2025-11-25" })),
+		).toBe(true);
+	});
+
+	test("treats DELETE as session termination", () => {
+		expect(isMcpRequest("DELETE", headers({}))).toBe(true);
+	});
+
+	test("never claims an ordinary browser request", () => {
+		const browser =
+			"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,*/*;q=0.8";
+		expect(isMcpRequest("GET", headers({ accept: browser }))).toBe(false);
+		expect(isMcpRequest("GET", headers({ accept: "text/markdown" }))).toBe(
+			false,
+		);
+		expect(isMcpRequest("GET", headers({}))).toBe(false);
+		expect(isMcpRequest("HEAD", headers({ accept: "text/html" }))).toBe(false);
+	});
+
+	test("does not claim a form post", () => {
+		expect(
+			isMcpRequest(
+				"POST",
+				headers({ "content-type": "application/x-www-form-urlencoded" }),
+			),
+		).toBe(false);
+	});
+});

--- a/lib/mcp-request.ts
+++ b/lib/mcp-request.ts
@@ -1,0 +1,54 @@
+/**
+ * Detects a Model Context Protocol request so the site root can serve both the
+ * landing page and the MCP server.
+ *
+ * Streamable HTTP is unambiguous enough to key on: clients POST JSON-RPC,
+ * open the stream with a `text/event-stream` GET, end a session with DELETE,
+ * and carry MCP-specific headers. A browser does none of those things, so the
+ * two audiences never collide on the same URL.
+ */
+
+/** Headers only an MCP client sends. */
+const MCP_HEADERS = ["mcp-session-id", "mcp-protocol-version"] as const;
+
+function hasMcpHeader(headers: Headers): boolean {
+	return MCP_HEADERS.some((name) => headers.has(name));
+}
+
+function acceptsEventStream(headers: Headers): boolean {
+	return (headers.get("accept") ?? "")
+		.toLowerCase()
+		.includes("text/event-stream");
+}
+
+function sendsJson(headers: Headers): boolean {
+	return (headers.get("content-type") ?? "")
+		.toLowerCase()
+		.includes("application/json");
+}
+
+/**
+ * True when this request should be handled by the MCP server rather than the
+ * page. Deliberately conservative: a plain GET for HTML or markdown is never
+ * treated as MCP.
+ */
+export function isMcpRequest(method: string, headers: Headers): boolean {
+	if (hasMcpHeader(headers)) return true;
+
+	switch (method.toUpperCase()) {
+		case "POST":
+			// JSON-RPC over Streamable HTTP.
+			return sendsJson(headers) || acceptsEventStream(headers);
+		case "GET":
+			// Opening the server-to-client stream.
+			return acceptsEventStream(headers);
+		case "DELETE":
+			// Ending a session.
+			return true;
+		default:
+			return false;
+	}
+}
+
+/** Where MCP requests are actually handled. */
+export const MCP_HANDLER_PATH = "/api/mcp";

--- a/lib/oauth-metadata.test.ts
+++ b/lib/oauth-metadata.test.ts
@@ -9,10 +9,11 @@ import { MCP_ENDPOINT, OAUTH_SCOPE_NAMES, SITE_URL } from "./site";
 describe("protected resource metadata", () => {
 	const metadata = protectedResourceMetadata(SITE_URL);
 
-	test("identifies the MCP endpoint, not the site origin", () => {
-		// Clients send this exact URI as the RFC 8707 resource parameter.
+	test("identifies the MCP endpoint, which is the site origin", () => {
+		// Clients send this exact URI as the RFC 8707 resource parameter, and
+		// the endpoint is now the origin itself.
 		expect(metadata.resource).toBe(MCP_ENDPOINT);
-		expect(metadata.resource).not.toBe(SITE_URL);
+		expect(metadata.resource).toBe(SITE_URL);
 	});
 
 	test("declares scopes and bearer usage", () => {
@@ -27,16 +28,21 @@ describe("protected resource metadata", () => {
 		);
 	});
 
-	test("metadata path follows RFC 9728 path insertion", () => {
+	test("a path-less resource takes the bare well-known path", () => {
+		// RFC 9728 inserts the resource path into the well-known URL. The
+		// resource is the origin, so there is no path to insert.
 		expect(RESOURCE_METADATA_PATH).toBe(
-			`/.well-known/oauth-protected-resource/${MCP_RESOURCE_PATH}`,
+			"/.well-known/oauth-protected-resource",
 		);
-		// The resource path must match the endpoint the metadata describes.
-		expect(MCP_ENDPOINT.endsWith(`/${MCP_RESOURCE_PATH}`)).toBe(true);
+	});
+
+	test("the legacy endpoint path is still known", () => {
+		// Its suffixed metadata stays served for clients configured on it.
+		expect(MCP_RESOURCE_PATH).toBe("api/mcp");
 	});
 
 	test("uses the caller's origin so previews describe themselves", () => {
 		const preview = protectedResourceMetadata("https://preview.example.com");
-		expect(preview.resource).toBe("https://preview.example.com/api/mcp");
+		expect(preview.resource).toBe("https://preview.example.com");
 	});
 });

--- a/lib/oauth-metadata.ts
+++ b/lib/oauth-metadata.ts
@@ -10,11 +10,16 @@ import { AUTH_SERVER_URL, OAUTH_SCOPE_NAMES, SITE_NAME } from "./site";
  * request; the bare path is still served for older clients.
  */
 
-/** Path segment of the MCP endpoint, without a leading slash. */
+/**
+ * The MCP endpoint is the site origin, so the resource has no path segment and
+ * RFC 9728 places its metadata at the bare well-known path. The legacy
+ * `/api/mcp` endpoint still answers, and its path-suffixed metadata is still
+ * served for clients configured against it.
+ */
 export const MCP_RESOURCE_PATH = "api/mcp";
 
 /** Where RFC 9728 says this resource's metadata lives. */
-export const RESOURCE_METADATA_PATH = `/.well-known/oauth-protected-resource/${MCP_RESOURCE_PATH}`;
+export const RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource";
 
 export interface ProtectedResourceMetadata {
 	resource: string;
@@ -29,7 +34,7 @@ export function protectedResourceMetadata(
 	origin: string,
 ): ProtectedResourceMetadata {
 	return {
-		resource: `${origin}/${MCP_RESOURCE_PATH}`,
+		resource: origin,
 		authorization_servers: [AUTH_SERVER_URL],
 		scopes_supported: OAUTH_SCOPE_NAMES,
 		bearer_methods_supported: ["header"],

--- a/lib/site-content.ts
+++ b/lib/site-content.ts
@@ -205,8 +205,7 @@ export const installTargets: InstallTarget[] = [
 			},
 			{
 				label: "Or use the hosted server",
-				command:
-					"claude mcp add --transport http bsv-mcp https://bsvmcp.com/api/mcp",
+				command: "claude mcp add --transport http bsv-mcp https://bsvmcp.com",
 			},
 		],
 		note: "The plugin bundles the server and registers it automatically, so no config file is needed.",
@@ -245,8 +244,7 @@ export const installTargets: InstallTarget[] = [
 		altCommands: [
 			{
 				label: "Or use the hosted server",
-				command:
-					"grok mcp add --transport http bsv-mcp https://bsvmcp.com/api/mcp",
+				command: "grok mcp add --transport http bsv-mcp https://bsvmcp.com",
 			},
 		],
 		configPath: "~/.grok/config.toml",
@@ -273,7 +271,7 @@ export const installTargets: InstallTarget[] = [
 		key: "other",
 		label: "Any MCP client",
 		command: "bunx bsv-mcp@latest",
-		note: "Any client that speaks MCP over stdio can run the server directly. For Streamable HTTP, point it at https://bsvmcp.com/api/mcp and authenticate with OAuth 2.1.",
+		note: "Any client that speaks MCP over stdio can run the server directly. For Streamable HTTP, point it at https://bsvmcp.com and authenticate with OAuth 2.1.",
 		docsUrl: "https://modelcontextprotocol.io",
 	},
 ];

--- a/lib/site.test.ts
+++ b/lib/site.test.ts
@@ -7,6 +7,7 @@ import {
 import {
 	getAppVersion,
 	MCP_ENDPOINT,
+	MCP_ENDPOINT_LEGACY,
 	MCP_PROTOCOL_LATEST,
 	MCP_PROTOCOL_SUPPORTED,
 	OAUTH_SCOPE_NAMES,
@@ -39,8 +40,15 @@ describe("urls", () => {
 		expect(SITE_URL.endsWith("/")).toBe(false);
 	});
 
-	test("mcp endpoint is derived from the site url", () => {
-		expect(MCP_ENDPOINT).toBe(`${SITE_URL}/api/mcp`);
+	test("mcp endpoint is the site origin, with nothing to append", () => {
+		// The root serves the landing page to browsers and the MCP server to
+		// MCP clients, so the connection URL is just the domain.
+		expect(MCP_ENDPOINT).toBe(SITE_URL);
+		expect(MCP_ENDPOINT.endsWith("/api/mcp")).toBe(false);
+	});
+
+	test("the original endpoint is still published for existing clients", () => {
+		expect(MCP_ENDPOINT_LEGACY).toBe(`${SITE_URL}/api/mcp`);
 	});
 });
 

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -31,8 +31,16 @@ export const GITHUB_URL = "https://github.com/b-open-io/bsv-mcp";
 export const NPM_URL = "https://www.npmjs.com/package/bsv-mcp";
 export const MCP_SPEC_URL = "https://modelcontextprotocol.io";
 
-/** The hosted Streamable HTTP endpoint MCP clients connect to. */
-export const MCP_ENDPOINT = `${SITE_URL}/api/mcp`;
+/**
+ * The hosted Streamable HTTP endpoint MCP clients connect to.
+ *
+ * It is the site origin: the root serves the landing page to browsers and the
+ * MCP server to MCP clients, so there is no path to append.
+ */
+export const MCP_ENDPOINT = SITE_URL;
+
+/** The original endpoint, still served for clients already configured on it. */
+export const MCP_ENDPOINT_LEGACY = `${SITE_URL}/api/mcp`;
 
 /** The OAuth 2.1 authorization server that issues tokens for this resource. */
 export const AUTH_SERVER_URL =

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,6 +5,7 @@ import {
 	selectMediaType,
 	VARY_HEADER,
 } from "@/lib/content-negotiation";
+import { isMcpRequest, MCP_HANDLER_PATH } from "@/lib/mcp-request";
 
 /**
  * Accept negotiation for the site's pages, per acceptmarkdown.com.
@@ -15,6 +16,20 @@ import {
  * that accepts neither gets 406 rather than the wrong media type.
  */
 export function middleware(request: NextRequest) {
+	// The site root is also the MCP endpoint, so `https://bsvmcp.com` is the
+	// whole connection URL with nothing to append. MCP requests are recognised
+	// by method and headers and rewritten to the handler; everything else falls
+	// through to page negotiation below. /api/mcp keeps working for clients
+	// already configured against it.
+	if (
+		request.nextUrl.pathname === "/" &&
+		isMcpRequest(request.method, request.headers)
+	) {
+		const url = request.nextUrl.clone();
+		url.pathname = MCP_HANDLER_PATH;
+		return NextResponse.rewrite(url);
+	}
+
 	const accept = request.headers.get("accept");
 	const chosen = selectMediaType(accept, OFFERED_MEDIA);
 


### PR DESCRIPTION
## Summary

The connection URL is now just `https://bsvmcp.com`, with no path to append. The domain already says mcp, so `bsvmcp.com/api/mcp` stuttered.

The root serves both audiences, decided by method and headers rather than by path: browsers get the landing page, MCP clients get the server. This is the same negotiation idea already used for markdown, keyed on a different signal.

## Why this is safe

Streamable HTTP is distinctive enough to key on. Clients POST JSON-RPC, open the stream with a `text/event-stream` GET, end sessions with DELETE, and carry `MCP-Session-Id` or `MCP-Protocol-Version`. A browser does none of those things, so the two audiences never collide on the same URL.

The detection is deliberately conservative and unit tested: a plain GET, a markdown GET, a HEAD and a form post are never treated as MCP.

`/api/mcp` keeps answering for clients already configured against it, and its path-suffixed RFC 9728 metadata is still served.

## Discovery consequence

Because the resource is now the origin, there is no path for RFC 9728 to insert, so its metadata moves to the bare well-known path and the challenge points there. The suffixed path stays for the legacy endpoint. `resource` in the metadata is the origin.

The published snippets, llms.txt and the markdown docs all now show the clean URL, generated from one constant.

## Testing

56 unit tests pass, 8 new covering the request detection: JSON-RPC POST, the streamable accept header, session and protocol headers, DELETE, and the negative cases above.

Verified on the public preview deployment before merging, which is what the deployment-protection change earlier enabled:

| Request | Result |
|---|---|
| POST / JSON-RPC | 401 from the MCP handler |
| GET / text/event-stream | 401 |
| DELETE / | 401 |
| GET / text/html | 200 HTML |
| GET / text/markdown | 200 markdown |
| POST /api/mcp | 401 |

The 401s are the correct unauthenticated response, and the challenge header confirms it is the MCP handler answering rather than the page. The metadata reports the origin as the resource.

Note this does not change the sign-in blocker from #15: registration on the authorization server still refuses unauthenticated clients, so a connector will reach authorization and stop there until that is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG

---
_Generated by [Claude Code](https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/bsv-mcp/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791325241&installation_model_id=435537&pr_number=17&repository=b-open-io%2Fbsv-mcp&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fbsv-mcp%2Fpull%2F17&signature=4ae400b9e02d238f63d5404e4dedfd3de00b8bbc431330c5879be0325f2858c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->