### PR TITLE
Rebrand to BSV blue and darken the navy

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,8 +9,8 @@
 		--card-foreground: 240 10% 3.9%;
 		--popover: 0 0% 100%;
 		--popover-foreground: 240 10% 3.9%;
-		--primary: 38 92% 45%;
-		--primary-foreground: 26 83% 8%;
+		--primary: 225 100% 50%;
+		--primary-foreground: 0 0% 100%;
 		--secondary: 240 4.8% 95.9%;
 		--secondary-foreground: 240 5.9% 10%;
 		--muted: 240 4.8% 95.9%;
@@ -25,10 +25,10 @@
 		--warning-foreground: 26 83% 8%;
 		--border: 240 5.9% 90%;
 		--input: 240 5.9% 90%;
-		--ring: 38 92% 45%;
+		--ring: 225 100% 50%;
 		--radius: 0.65rem;
 
-		--chart-1: 38 92% 50%;
+		--chart-1: 225 100% 50%;
 		--chart-2: 173 58% 39%;
 		--chart-3: 197 37% 24%;
 		--chart-4: 43 74% 66%;
@@ -41,23 +41,23 @@
 		--sidebar-accent: 240 4.8% 95.9%;
 		--sidebar-accent-foreground: 240 5.9% 10%;
 		--sidebar-border: 220 13% 91%;
-		--sidebar-ring: 38 92% 45%;
+		--sidebar-ring: 225 100% 50%;
 	}
 
 	.dark {
-		--background: 222 47% 5%;
+		--background: 228 60% 3%;
 		--foreground: 210 40% 98%;
-		--card: 222 44% 7.5%;
+		--card: 226 50% 5.5%;
 		--card-foreground: 210 40% 98%;
-		--popover: 222 44% 7.5%;
+		--popover: 226 50% 5.5%;
 		--popover-foreground: 210 40% 98%;
-		--primary: 38 92% 50%;
-		--primary-foreground: 26 83% 8%;
-		--secondary: 217 33% 15%;
+		--primary: 225 100% 58%;
+		--primary-foreground: 0 0% 100%;
+		--secondary: 226 40% 11%;
 		--secondary-foreground: 210 40% 98%;
-		--muted: 217 33% 15%;
+		--muted: 226 40% 11%;
 		--muted-foreground: 215 20% 65%;
-		--accent: 217 33% 17%;
+		--accent: 226 40% 13%;
 		--accent-foreground: 210 40% 98%;
 		--destructive: 0 72% 51%;
 		--destructive-foreground: 0 0% 98%;
@@ -65,24 +65,24 @@
 		--success-foreground: 144 80% 6%;
 		--warning: 38 92% 50%;
 		--warning-foreground: 26 83% 8%;
-		--border: 217 33% 17%;
-		--input: 217 33% 17%;
-		--ring: 38 92% 50%;
+		--border: 226 38% 13%;
+		--input: 226 38% 13%;
+		--ring: 225 100% 58%;
 
-		--chart-1: 38 92% 50%;
+		--chart-1: 225 100% 58%;
 		--chart-2: 160 60% 45%;
 		--chart-3: 0 72% 58%;
 		--chart-4: 280 65% 65%;
-		--chart-5: 200 80% 55%;
+		--chart-5: 30 90% 60%;
 
-		--sidebar: 222 44% 7.5%;
+		--sidebar: 226 50% 5.5%;
 		--sidebar-foreground: 210 40% 98%;
-		--sidebar-primary: 38 92% 50%;
-		--sidebar-primary-foreground: 26 83% 8%;
-		--sidebar-accent: 217 33% 17%;
+		--sidebar-primary: 225 100% 58%;
+		--sidebar-primary-foreground: 0 0% 100%;
+		--sidebar-accent: 226 40% 13%;
 		--sidebar-accent-foreground: 210 40% 98%;
-		--sidebar-border: 217 33% 17%;
-		--sidebar-ring: 38 92% 50%;
+		--sidebar-border: 226 38% 13%;
+		--sidebar-ring: 225 100% 58%;
 	}
 
 	* {

--- a/components/landing/TerminalDemo.tsx
+++ b/components/landing/TerminalDemo.tsx
@@ -1,6 +1,6 @@
 import { Card } from "@/components/ui/card";
 
-const trafficLights = ["bg-chart-3", "bg-chart-1", "bg-chart-2"];
+const trafficLights = ["bg-chart-3", "bg-warning", "bg-chart-2"];
 
 export function TerminalDemo() {
 	return (


### PR DESCRIPTION
## Summary

Orange is Bitcoin's color, not BSV's. The BSV Blockchain logo, pulled directly from their site's SVG, is `#003FFF`: an electric blue at hue 225, with `#1B1EA9` as its darker companion. Primary is now that blue with a white foreground, which measures 6.7:1 on the brand value.

The whole dark scale moves onto the same hue and gets darker: background, card, popover, muted, accent, border and the sidebar tokens.

## One deliberate deviation

In dark mode, primary is lifted one step to 58% lightness. The exact brand value as small link text on the darker ground falls under 3:1, which would fail accessibility for the "Or run it locally" and "Full tool reference" links. Buttons and light mode keep `#003FFF` exactly, so the brand value is what people see on every filled surface.

## Knock-on changes

- Ring, chart-1 and sidebar-primary follow primary.
- chart-5 moves off blue so the chart palette stays distinct.
- The terminal mock's middle traffic light used chart-1, which is now blue, so it uses the semantic `warning` token to stay yellow. `warning` itself stays amber, since it is a meaning rather than a brand.

## Note on this PR's history

Opened for the paid-ask proposal; a branch reset while shipping this replaced its head. The proposal is being re-opened separately.

## Verification

Screenshotted at 390px and 1280px on a production build. No horizontal overflow. 58 tests pass. No amber remains in the theme outside the `warning` token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG