### PR TITLE
Rebuild the landing page on landing-page craft, yellow on black

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -94,3 +94,18 @@
 		color: hsl(var(--foreground));
 	}
 }
+
+@keyframes cursor-blink {
+	0%,
+	49% {
+		opacity: 1;
+	}
+	50%,
+	100% {
+		opacity: 0;
+	}
+}
+
+.cursor-blink {
+	animation: cursor-blink 1.1s steps(1) infinite;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,8 +9,8 @@
 		--card-foreground: 240 10% 3.9%;
 		--popover: 0 0% 100%;
 		--popover-foreground: 240 10% 3.9%;
-		--primary: 225 100% 50%;
-		--primary-foreground: 0 0% 100%;
+		--primary: 47 100% 47%;
+		--primary-foreground: 0 0% 4%;
 		--secondary: 240 4.8% 95.9%;
 		--secondary-foreground: 240 5.9% 10%;
 		--muted: 240 4.8% 95.9%;
@@ -25,10 +25,10 @@
 		--warning-foreground: 26 83% 8%;
 		--border: 240 5.9% 90%;
 		--input: 240 5.9% 90%;
-		--ring: 225 100% 50%;
-		--radius: 0.65rem;
+		--ring: 47 100% 47%;
+		--radius: 0.375rem;
 
-		--chart-1: 225 100% 50%;
+		--chart-1: 47 100% 47%;
 		--chart-2: 173 58% 39%;
 		--chart-3: 197 37% 24%;
 		--chart-4: 43 74% 66%;
@@ -41,48 +41,48 @@
 		--sidebar-accent: 240 4.8% 95.9%;
 		--sidebar-accent-foreground: 240 5.9% 10%;
 		--sidebar-border: 220 13% 91%;
-		--sidebar-ring: 225 100% 50%;
+		--sidebar-ring: 47 100% 47%;
 	}
 
 	.dark {
-		--background: 228 60% 3%;
-		--foreground: 210 40% 98%;
-		--card: 226 50% 5.5%;
-		--card-foreground: 210 40% 98%;
-		--popover: 226 50% 5.5%;
-		--popover-foreground: 210 40% 98%;
-		--primary: 225 100% 58%;
-		--primary-foreground: 0 0% 100%;
-		--secondary: 226 40% 11%;
-		--secondary-foreground: 210 40% 98%;
-		--muted: 226 40% 11%;
-		--muted-foreground: 215 20% 65%;
-		--accent: 226 40% 13%;
-		--accent-foreground: 210 40% 98%;
+		--background: 0 0% 4%;
+		--foreground: 0 0% 96%;
+		--card: 0 0% 6%;
+		--card-foreground: 0 0% 96%;
+		--popover: 0 0% 6%;
+		--popover-foreground: 0 0% 96%;
+		--primary: 47 100% 50%;
+		--primary-foreground: 0 0% 4%;
+		--secondary: 0 0% 11%;
+		--secondary-foreground: 0 0% 96%;
+		--muted: 0 0% 11%;
+		--muted-foreground: 0 0% 62%;
+		--accent: 0 0% 13%;
+		--accent-foreground: 0 0% 96%;
 		--destructive: 0 72% 51%;
 		--destructive-foreground: 0 0% 98%;
 		--success: 142 69% 45%;
 		--success-foreground: 144 80% 6%;
 		--warning: 38 92% 50%;
 		--warning-foreground: 26 83% 8%;
-		--border: 226 38% 13%;
-		--input: 226 38% 13%;
-		--ring: 225 100% 58%;
+		--border: 0 0% 15%;
+		--input: 0 0% 15%;
+		--ring: 47 100% 50%;
 
-		--chart-1: 225 100% 58%;
+		--chart-1: 47 100% 50%;
 		--chart-2: 160 60% 45%;
 		--chart-3: 0 72% 58%;
 		--chart-4: 280 65% 65%;
 		--chart-5: 30 90% 60%;
 
-		--sidebar: 226 50% 5.5%;
-		--sidebar-foreground: 210 40% 98%;
-		--sidebar-primary: 225 100% 58%;
-		--sidebar-primary-foreground: 0 0% 100%;
-		--sidebar-accent: 226 40% 13%;
-		--sidebar-accent-foreground: 210 40% 98%;
-		--sidebar-border: 226 38% 13%;
-		--sidebar-ring: 225 100% 58%;
+		--sidebar: 0 0% 6%;
+		--sidebar-foreground: 0 0% 96%;
+		--sidebar-primary: 47 100% 50%;
+		--sidebar-primary-foreground: 0 0% 4%;
+		--sidebar-accent: 0 0% 13%;
+		--sidebar-accent-foreground: 0 0% 96%;
+		--sidebar-border: 0 0% 15%;
+		--sidebar-ring: 47 100% 50%;
 	}
 
 	* {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,10 +99,15 @@ export default function LandingPage() {
 			/>
 
 			<header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
-				<Link href="/" className="flex items-center gap-2 font-semibold">
-					<span className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground">
-						<Bitcoin className="size-4" />
-					</span>
+				<Link
+					href="/"
+					className="flex items-center gap-2 font-mono font-semibold tracking-tight"
+				>
+					<Bitcoin
+						className="size-6 text-primary"
+						strokeWidth={2.5}
+						aria-hidden
+					/>
 					BSV MCP
 				</Link>
 				<nav className="flex items-center gap-1">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,19 @@
 import {
 	ArrowRight,
 	Bitcoin,
+	Check,
 	Cloud,
 	Fingerprint,
 	Github,
 	Image as ImageIcon,
 	KeyRound,
 	MessageSquare,
-	Plug,
 	Search,
 	Server,
 	ShieldCheck,
 	Terminal,
 	Wallet,
+	X,
 } from "lucide-react";
 import Link from "next/link";
 import { CopyCommand } from "@/components/landing/CopyCommand";
@@ -27,7 +28,6 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import {
 	GITHUB_URL,
 	getAppVersion,
@@ -37,10 +37,12 @@ import {
 import {
 	clients,
 	deployModes,
+	faq,
 	guarantees,
+	hero,
 	installCommands,
 	installTargets,
-	steps,
+	problem,
 	toolCategories,
 } from "@/lib/site-content";
 import { approximateTotal, countTools, getToolCounts } from "@/lib/tool-count";
@@ -67,22 +69,49 @@ const guaranteeIconFor: Record<string, typeof Wallet> = {
 	"external-signer": Wallet,
 };
 
+/** Uppercase mono label above a section title, `#`-prefixed like a shell comment. */
+function Eyebrow({ children }: { children: React.ReactNode }) {
+	return (
+		<p className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
+			<span className="text-primary">#</span> {children}
+		</p>
+	);
+}
+
 function SectionHeading({
+	eyebrow,
 	title,
 	description,
 	action,
 }: {
+	eyebrow: string;
 	title: string;
-	description: string;
+	description?: string;
 	action?: React.ReactNode;
 }) {
 	return (
 		<div className="mb-10 flex flex-wrap items-end justify-between gap-4">
 			<div className="max-w-2xl space-y-3">
+				<Eyebrow>{eyebrow}</Eyebrow>
 				<h2 className="text-3xl font-bold tracking-tight">{title}</h2>
-				<p className="text-muted-foreground">{description}</p>
+				{description ? (
+					<p className="text-muted-foreground">{description}</p>
+				) : null}
 			</div>
 			{action}
+		</div>
+	);
+}
+
+function Stat({ value, label }: { value: string; label: string }) {
+	return (
+		<div className="space-y-1">
+			<p className="font-mono text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+				{value}
+			</p>
+			<p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+				{label}
+			</p>
 		</div>
 	);
 }
@@ -90,15 +119,11 @@ function SectionHeading({
 export default function LandingPage() {
 	const toolCounts = getToolCounts();
 	const headlineTotal = approximateTotal(toolCounts.total);
+	const version = getAppVersion();
 
 	return (
 		<div className="relative min-h-screen overflow-x-hidden">
-			<div
-				aria-hidden
-				className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[560px] bg-[radial-gradient(ellipse_at_top,hsl(var(--primary)/0.1),transparent_60%)]"
-			/>
-
-			<header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
+			<header className="mx-auto flex max-w-5xl items-center justify-between px-6 py-5">
 				<Link
 					href="/"
 					className="flex items-center gap-2 font-mono font-semibold tracking-tight"
@@ -110,101 +135,134 @@ export default function LandingPage() {
 					/>
 					BSV MCP
 				</Link>
-				<nav className="flex items-center gap-1">
+				<nav className="flex items-center gap-1 font-mono text-sm">
 					<Button variant="ghost" asChild className="hidden sm:inline-flex">
-						<a href="#tools">Tools</a>
+						<a href="#tools">/tools</a>
 					</Button>
 					<Button variant="ghost" asChild className="hidden sm:inline-flex">
-						<a href="#install">Install</a>
+						<a href="#install">/install</a>
+					</Button>
+					<Button variant="ghost" asChild className="hidden sm:inline-flex">
+						<a href="#faq">/faq</a>
 					</Button>
 					<Button variant="ghost" asChild>
 						<a href={GITHUB_URL} target="_blank" rel="noreferrer">
 							<Github />
-							<span className="hidden sm:inline">GitHub</span>
+							<span className="hidden sm:inline">github</span>
 						</a>
-					</Button>
-					<Button asChild className="ml-2 hidden sm:inline-flex">
-						<Link href="/connect">Get started</Link>
 					</Button>
 				</nav>
 			</header>
 
-			<section className="mx-auto grid max-w-6xl items-center gap-10 px-6 pb-16 pt-8 sm:pt-12 lg:grid-cols-[1.1fr_1fr] lg:gap-12 lg:pb-20 lg:pt-20">
-				<div className="min-w-0 space-y-6">
-					<h1 className="text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl">
-						Give your AI agent a{" "}
-						<span className="text-primary">Bitcoin wallet</span>.
+			{/* Hero: header answers "what is this" alone; the sub carries the proof;
+			    the install command is the lowest-labour action a developer can take. */}
+			<section className="mx-auto max-w-5xl px-6 pb-14 pt-10 sm:pt-16 lg:pt-24">
+				<div className="mx-auto max-w-3xl space-y-6 text-center">
+					<Eyebrow>
+						{hero.eyebrow}
+						{headlineTotal ? ` · ${headlineTotal} tools` : ""} · v{version}
+					</Eyebrow>
+					<h1 className="text-4xl font-bold leading-[1.08] tracking-tight sm:text-5xl lg:text-6xl">
+						The Bitcoin SV wallet for{" "}
+						<span className="font-mono tracking-tight text-primary">
+							MCP clients
+						</span>
+						.
 					</h1>
-					<p className="max-w-xl text-base text-muted-foreground sm:text-lg">
-						An open source MCP server that lets Claude, Cursor, and any MCP
-						client send BSV, inscribe ordinals, and read the chain.{" "}
-						{headlineTotal ? `${headlineTotal} tools, one install.` : ""}
+					<p className="mx-auto max-w-2xl text-base text-muted-foreground sm:text-lg">
+						{hero.sub}
 					</p>
-					<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-5">
-						<Button size="xl" asChild>
-							<Link href="/connect">
-								Connect the hosted server
-								<ArrowRight />
-							</Link>
-						</Button>
-						<Button
-							variant="link"
-							asChild
-							className="h-auto justify-start px-0 sm:justify-center"
-						>
-							<a href="#install">
-								<Terminal />
-								Or run it locally
-							</a>
-						</Button>
+					<div className="mx-auto max-w-xl space-y-3 pt-2">
+						<CopyCommand command={installCommands.claudeCode} />
+						<div className="flex flex-col justify-center gap-3 sm:flex-row">
+							<Button size="xl" asChild>
+								<Link href="/connect">
+									Connect the hosted server
+									<ArrowRight />
+								</Link>
+							</Button>
+							<Button size="xl" variant="outline" asChild>
+								<a href={GITHUB_URL} target="_blank" rel="noreferrer">
+									<Github />
+									Clone source
+								</a>
+							</Button>
+						</div>
 					</div>
-					<CopyCommand
-						command={installCommands.claudeCode}
-						className="hidden max-w-xl sm:flex"
-					/>
 				</div>
-				<TerminalDemo />
+
+				<div className="mx-auto mt-14 max-w-3xl">
+					<TerminalDemo />
+				</div>
 			</section>
 
+			{/* Trust: numbers instead of logos, since this is an individual-oriented tool. */}
 			<section className="border-y bg-card/40">
-				<div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-10 gap-y-3 px-6 py-6 text-sm text-muted-foreground">
-					<span className="text-xs uppercase tracking-wider">Works with</span>
-					{clients.map((client) => (
-						<span key={client}>{client}</span>
-					))}
+				<div className="mx-auto grid max-w-5xl grid-cols-2 gap-8 px-6 py-10 sm:grid-cols-4">
+					<Stat value={String(toolCounts.total)} label="tools" />
+					<Stat value="MIT" label="open source" />
+					<Stat
+						value={String(installTargets.length - 1)}
+						label="clients documented"
+					/>
+					<Stat value={MCP_PROTOCOL_LATEST} label="mcp protocol" />
 				</div>
 			</section>
 
-			<section className="mx-auto max-w-6xl px-6 py-20">
+			{/* Problem before solution. */}
+			<section className="mx-auto max-w-5xl px-6 py-20">
 				<SectionHeading
-					title="From prompt to txid in three steps"
-					description="No SDK to learn. The agent reads the tool schemas and does the rest."
+					eyebrow="why"
+					title="Wallet code is the part of every agent nobody wants to write."
 				/>
-				<ol className="grid gap-6 md:grid-cols-3">
-					{steps.map((step, index) => (
-						<li key={step.title}>
-							<Card className="h-full bg-card/60">
-								<CardHeader>
-									<span className="font-mono text-xs text-primary">
-										0{index + 1}
-									</span>
-									<CardTitle className="text-lg">{step.title}</CardTitle>
-									<CardDescription>{step.description}</CardDescription>
-								</CardHeader>
-							</Card>
-						</li>
-					))}
-				</ol>
+				<div className="grid gap-4 md:grid-cols-2">
+					<Card className="bg-card/60">
+						<CardHeader>
+							<CardTitle className="font-mono text-sm uppercase tracking-wider text-muted-foreground">
+								without
+							</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<ul className="space-y-3">
+								{problem.without.map((line) => (
+									<li key={line} className="flex gap-3 text-sm">
+										<X className="mt-0.5 size-4 shrink-0 text-destructive" />
+										<span className="text-muted-foreground">{line}</span>
+									</li>
+								))}
+							</ul>
+						</CardContent>
+					</Card>
+					<Card className="border-primary/40 bg-card/60">
+						<CardHeader>
+							<CardTitle className="font-mono text-sm uppercase tracking-wider text-primary">
+								with bsv-mcp
+							</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<ul className="space-y-3">
+								{problem.with.map((line) => (
+									<li key={line} className="flex gap-3 text-sm">
+										<Check className="mt-0.5 size-4 shrink-0 text-success" />
+										<span>{line}</span>
+									</li>
+								))}
+							</ul>
+						</CardContent>
+					</Card>
+				</div>
 			</section>
 
-			<section id="tools" className="mx-auto max-w-6xl px-6 pb-20">
+			{/* Tools: features tied back to the value prop, each with its live count. */}
+			<section id="tools" className="mx-auto max-w-5xl px-6 pb-20">
 				<SectionHeading
-					title="Everything on-chain, as tools"
+					eyebrow="tools"
+					title="Everything on-chain, as tools your agent can call."
 					description="Each category can be toggled with an environment variable. Tools that need keys fail gracefully when none are configured."
 					action={
-						<Button variant="link" asChild className="px-0">
+						<Button variant="link" asChild className="px-0 font-mono">
 							<a href={`${GITHUB_URL}#readme`} target="_blank" rel="noreferrer">
-								Full tool reference
+								full reference
 								<ArrowRight />
 							</a>
 						</Button>
@@ -217,18 +275,16 @@ export default function LandingPage() {
 						return (
 							<Card
 								key={name}
-								className="h-full bg-card/60 transition-colors hover:border-primary/40"
+								className="h-full bg-card/60 transition-colors hover:border-primary/50"
 							>
 								<CardHeader>
 									<div className="flex items-start justify-between gap-3">
-										<span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-											<Icon className="size-5" />
-										</span>
-										{count > 0 && (
-											<Badge variant="secondary">
+										<Icon className="size-5 text-primary" />
+										{count > 0 ? (
+											<Badge variant="secondary" className="font-mono">
 												{count} {count === 1 ? "tool" : "tools"}
 											</Badge>
-										)}
+										) : null}
 									</div>
 									<CardTitle className="pt-2">{name}</CardTitle>
 									<CardDescription>{description}</CardDescription>
@@ -239,10 +295,12 @@ export default function LandingPage() {
 				</div>
 			</section>
 
+			{/* Install: the same server three ways, then the exact config per client. */}
 			<section id="install" className="border-t bg-card/30">
-				<div className="mx-auto max-w-6xl px-6 py-20">
+				<div className="mx-auto max-w-5xl px-6 py-20">
 					<SectionHeading
-						title="Run it your way"
+						eyebrow="install"
+						title="Run it your way."
 						description="The same server ships in three shapes. Pick the one that fits your client and your key custody."
 					/>
 					<div className="grid gap-4 md:grid-cols-3">
@@ -269,81 +327,96 @@ export default function LandingPage() {
 						})}
 					</div>
 
-					<Separator className="my-10" />
-
-					<div className="space-y-4">
-						<p className="flex items-center gap-2 text-sm font-medium">
-							<Plug className="size-4 text-primary" />
-							Pick your client
-						</p>
+					<div className="mt-12 space-y-4">
+						<Eyebrow>pick your client</Eyebrow>
 						<InstallTabs targets={installTargets} />
 					</div>
+
+					<p className="mt-8 font-mono text-xs uppercase tracking-wider text-muted-foreground">
+						works with {clients.join(" · ")}
+					</p>
 				</div>
 			</section>
 
-			<section className="mx-auto max-w-6xl px-6 py-20">
-				<div className="grid gap-8 lg:grid-cols-[1fr_1.2fr] lg:items-center">
-					<div className="space-y-3">
-						<h2 className="text-3xl font-bold tracking-tight">
-							Keys stay yours
-						</h2>
-						<p className="text-muted-foreground">
-							An agent with a wallet needs guardrails. BSV MCP is built so the
-							model can act without ever seeing raw key material in a prompt.
-						</p>
+			{/* Key custody: the objection every wallet has to answer. */}
+			<section className="mx-auto max-w-5xl px-6 py-20">
+				<SectionHeading
+					eyebrow="keys"
+					title="Your keys never end up in a prompt."
+					description="An agent with a wallet needs guardrails. The model can act without ever seeing raw key material."
+				/>
+				<ul className="grid gap-4 sm:grid-cols-2">
+					{guarantees.map(({ key, title, description }) => {
+						const Icon = guaranteeIconFor[key];
+						return (
+							<li key={key}>
+								<Card className="h-full bg-card/60">
+									<CardHeader>
+										<Icon className="size-5 text-primary" />
+										<CardTitle className="pt-2">{title}</CardTitle>
+										<CardDescription>{description}</CardDescription>
+									</CardHeader>
+								</Card>
+							</li>
+						);
+					})}
+				</ul>
+			</section>
+
+			{/* FAQ: the questions a developer asks before installing anything. */}
+			<section id="faq" className="mx-auto max-w-5xl px-6 pb-20">
+				<SectionHeading eyebrow="faq" title="Before you install." />
+				<dl className="divide-y border-y">
+					{faq.map((item) => (
+						<div
+							key={item.q}
+							className="grid gap-2 py-6 md:grid-cols-[1fr_2fr] md:gap-8"
+						>
+							<dt className="font-semibold">{item.q}</dt>
+							<dd className="text-sm text-muted-foreground">{item.a}</dd>
+						</div>
+					))}
+				</dl>
+			</section>
+
+			{/* Final CTA on a distinct band, for readers who scroll to the end before deciding. */}
+			<section className="mx-auto max-w-5xl px-6 pb-24">
+				<div className="rounded-lg bg-primary px-8 py-12 text-primary-foreground sm:px-12">
+					<div className="flex flex-col items-start justify-between gap-6 md:flex-row md:items-center">
+						<div className="space-y-2">
+							<p className="font-mono text-xs uppercase tracking-[0.2em] opacity-70">
+								# ship
+							</p>
+							<h2 className="text-3xl font-bold tracking-tight">
+								Put your agent on-chain.
+							</h2>
+							<p className="max-w-md opacity-80">
+								One command. Your first transaction from a chat window in under
+								two minutes.
+							</p>
+						</div>
+						<div className="flex flex-col gap-3 sm:flex-row">
+							<Button
+								size="xl"
+								variant="secondary"
+								asChild
+								className="bg-primary-foreground text-primary hover:bg-primary-foreground/90"
+							>
+								<Link href="/connect">
+									Connect the hosted server
+									<ArrowRight />
+								</Link>
+							</Button>
+						</div>
 					</div>
-					<ul className="grid gap-4 sm:grid-cols-2">
-						{guarantees.map(({ key, title, description }) => {
-							const Icon = guaranteeIconFor[key];
-							return (
-								<li key={key}>
-									<Card className="h-full bg-card/60">
-										<CardHeader>
-											<Icon className="size-5 text-primary" />
-											<CardTitle className="pt-2">{title}</CardTitle>
-											<CardDescription>{description}</CardDescription>
-										</CardHeader>
-									</Card>
-								</li>
-							);
-						})}
-					</ul>
 				</div>
-			</section>
-
-			<section className="mx-auto max-w-6xl px-6 pb-24">
-				<Card className="overflow-hidden border-primary/30 bg-gradient-to-br from-primary/15 via-card to-card text-center">
-					<CardHeader className="items-center gap-3 p-10">
-						<CardTitle className="text-3xl font-bold tracking-tight">
-							Put your agent on-chain
-						</CardTitle>
-						<CardDescription className="mx-auto max-w-xl text-base">
-							Generate a key, download the backup, paste the config. You&apos;ll
-							be sending a transaction from a chat window in under two minutes.
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="flex flex-col justify-center gap-3 pb-10 sm:flex-row">
-						<Button size="xl" asChild>
-							<Link href="/connect">
-								Get started
-								<ArrowRight />
-							</Link>
-						</Button>
-						<Button size="xl" variant="outline" asChild>
-							<a href={GITHUB_URL} target="_blank" rel="noreferrer">
-								<Github />
-								Star on GitHub
-							</a>
-						</Button>
-					</CardContent>
-				</Card>
 			</section>
 
 			<footer className="border-t">
-				<div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-8 text-sm text-muted-foreground">
+				<div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-4 px-6 py-8 font-mono text-xs text-muted-foreground">
 					<p>
-						© {new Date().getFullYear()} BSV MCP · MIT License · v
-						{getAppVersion()} · MCP protocol {MCP_PROTOCOL_LATEST}
+						© {new Date().getFullYear()} bsv-mcp · MIT · v{version} · mcp{" "}
+						{MCP_PROTOCOL_LATEST}
 					</p>
 					<div className="flex flex-wrap gap-6">
 						<a
@@ -352,7 +425,7 @@ export default function LandingPage() {
 							rel="noreferrer"
 							className="hover:text-foreground"
 						>
-							GitHub
+							github
 						</a>
 						<a
 							href={NPM_URL}
@@ -363,15 +436,23 @@ export default function LandingPage() {
 							npm
 						</a>
 						<a
+							href={`${GITHUB_URL}/blob/master/CHANGELOG.md`}
+							target="_blank"
+							rel="noreferrer"
+							className="hover:text-foreground"
+						>
+							changelog
+						</a>
+						<a
 							href="https://modelcontextprotocol.io"
 							target="_blank"
 							rel="noreferrer"
 							className="hover:text-foreground"
 						>
-							MCP spec
+							mcp spec
 						</a>
 						<Link href="/connect" className="hover:text-foreground">
-							Hosted service
+							hosted
 						</Link>
 					</div>
 				</div>

--- a/components/landing/CopyCommand.tsx
+++ b/components/landing/CopyCommand.tsx
@@ -33,7 +33,7 @@ export function CopyCommand({ command, className }: CopyCommandProps) {
 			<span aria-hidden className="select-none text-primary">
 				$
 			</span>
-			<code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-foreground">
+			<code className="min-w-0 flex-1 whitespace-normal break-all text-foreground sm:overflow-x-auto sm:whitespace-nowrap">
 				{command}
 			</code>
 			<Button

--- a/components/landing/TerminalDemo.tsx
+++ b/components/landing/TerminalDemo.tsx
@@ -1,10 +1,41 @@
 import { Card } from "@/components/ui/card";
+import { replay } from "@/lib/site-content";
 
 const trafficLights = ["bg-chart-3", "bg-warning", "bg-chart-2"];
 
-export function TerminalDemo() {
+/** Colour a replay line by what it is: a shell prompt, a chat prompt, a tool call, or output. */
+function lineClass(line: string): string {
+	if (line.startsWith("$ ")) return "text-foreground";
+	if (line.startsWith("> ")) return "text-foreground";
+	if (line.startsWith("● ")) return "text-muted-foreground";
+	if (line.startsWith("  ")) return "text-muted-foreground/70";
+	if (line.startsWith("✓")) return "text-success";
+	return "text-foreground";
+}
+
+/** The leading glyph gets the accent so the eye finds each step's start. */
+function splitLead(line: string): [string, string] {
+	const match = line.match(/^(\$ |> |● |✓ )/);
+	if (!match) return ["", line];
+	return [match[1], line.slice(match[1].length)];
+}
+
+interface TerminalDemoProps {
+	/** Figure label shown in the title bar, in the style of a numbered figure. */
+	figure?: string;
+}
+
+/**
+ * One terminal session from install to txid, as a numbered replay.
+ *
+ * The steps come from `replay` in site-content, so the walkthrough on the
+ * page and the one in the markdown docs describe the same session.
+ */
+export function TerminalDemo({
+	figure = "fig. 1 — prompt to txid",
+}: TerminalDemoProps) {
 	return (
-		<Card className="min-w-0 overflow-hidden bg-card/80 py-0 shadow-2xl">
+		<Card className="min-w-0 overflow-hidden bg-card py-0">
 			<div className="flex items-center gap-2 border-b px-4 py-2.5">
 				{trafficLights.map((color) => (
 					<span
@@ -14,38 +45,39 @@ export function TerminalDemo() {
 					/>
 				))}
 				<span className="ml-2 font-mono text-xs text-muted-foreground">
-					claude
+					<span className="text-primary">&gt;_</span> {figure}
 				</span>
 			</div>
-			<div className="space-y-4 break-words p-5 font-mono text-[13px] leading-relaxed">
-				<p>
+			<ol className="space-y-5 break-words p-5 font-mono text-[13px] leading-relaxed">
+				{replay.map((step, index) => (
+					<li key={step.label} className="space-y-1">
+						<p className="text-[11px] uppercase tracking-wider text-muted-foreground/60">
+							<span className="text-primary">0{index + 1}</span> {step.label}
+						</p>
+						{step.lines.map((line) => {
+							const [lead, rest] = splitLead(line);
+							return (
+								<p key={line} className={lineClass(line)}>
+									{lead ? (
+										<span
+											className={
+												lead.startsWith("✓") ? "text-success" : "text-primary"
+											}
+										>
+											{lead}
+										</span>
+									) : null}
+									{rest}
+								</p>
+							);
+						})}
+					</li>
+				))}
+				<li aria-hidden className="text-foreground">
 					<span className="text-primary">&gt; </span>
-					<span className="text-foreground">
-						inscribe hello.svg as a 1sat ordinal and tell me the txid
-					</span>
-				</p>
-				<div className="space-y-1 text-muted-foreground">
-					<p>
-						<span className="text-success">●</span> wallet_createOrdinals(file:
-						&quot;hello.svg&quot;, contentType: &quot;image/svg+xml&quot;)
-					</p>
-					<p className="pl-4 text-muted-foreground/70">
-						├ reading file (412 bytes)
-					</p>
-					<p className="pl-4 text-muted-foreground/70">
-						├ selecting UTXOs · fee 1 sat/kb
-					</p>
-					<p className="pl-4 text-muted-foreground/70">└ broadcast ✓</p>
-				</div>
-				<p className="text-foreground">
-					Inscribed. Outpoint <span className="text-primary">f3a1…9c2e_0</span>{" "}
-					— view it on{" "}
-					<span className="underline decoration-muted-foreground/40">
-						1satordinals.com
-					</span>
-					.
-				</p>
-			</div>
+					<span className="cursor-blink inline-block h-[1.1em] w-[0.6em] translate-y-[0.2em] bg-primary" />
+				</li>
+			</ol>
 		</Card>
 	);
 }

--- a/docs/plans/paid-ask.md
+++ b/docs/plans/paid-ask.md
@@ -1,0 +1,130 @@
+# Paid ask: overpowered.bot as a premium feature
+
+Status: proposal. Nothing here is implemented yet.
+
+## What this is
+
+overpowered.bot (Satchmo) already exposes a remote MCP endpoint with two
+tiers. Read-only tools are anonymous and rate limited; `satchmo_chat`,
+`satchmo_run_skill` and `satchmo_set_mood` require a bearer token. The bearer
+is a single shared secret, so it answers "is this caller allowed" but cannot
+answer "has this caller paid" — every caller presents the same string.
+
+bsv-mcp has what is missing: per-user identity from sigma-auth, a wallet, and
+an approval prompt. So the split is:
+
+- **Satchmo is the brain.** It states a price and verifies payment.
+- **bsv-mcp is the wallet.** It pays the price and retries.
+
+The touchpoint is `satchmo_chat`. It is already the tier boundary and already
+the expensive call, because it runs an eve agent session.
+
+Keeping the protocol payment-shaped rather than bsv-mcp-shaped matters: any
+wallet-capable MCP client can satisfy it, and Satchmo does not take a
+dependency on this project.
+
+## Decisions taken
+
+Per-call payment was the starting request. Two adjustments, both chosen as the
+more generous option for the caller:
+
+1. **Payment tops up a balance rather than settling each call.** Strictly
+   per-call means every ask waits on a broadcast and burns fees on a call that
+   is already slow because an agent is thinking. One payment buys many asks.
+   Pricing is still expressed per ask.
+2. **Either satoshis or MNEE is accepted.** The challenge advertises both, and
+   the caller pays in whichever it holds. MNEE gives predictable pricing, sats
+   avoid a token dependency.
+
+A free allowance per identity is included, so a first-time caller can try an
+ask before being asked for anything.
+
+## The protocol
+
+### 1. Unpaid call
+
+Satchmo answers a `satchmo_chat` call from a caller with no balance with a
+payment challenge rather than a bare 401:
+
+```http
+HTTP/1.1 402 Payment Required
+Content-Type: application/json
+```
+
+```json
+{
+  "error": "payment_required",
+  "challenge": {
+    "nonce": "01J...",
+    "expires_at": "2026-09-06T22:10:00Z",
+    "unit": "ask",
+    "prices": [
+      { "currency": "BSV", "amount": 5000, "address": "1..." },
+      { "currency": "MNEE", "amount": 10, "address": "1..." }
+    ],
+    "min_top_up_units": 10,
+    "free_units_remaining": 0
+  }
+}
+```
+
+The `nonce` is the important part. Without a server-issued value bound into
+the payment, a single receipt is replayable and buys unlimited asks.
+
+### 2. Payment
+
+The caller pays one of the advertised prices, including the nonce in the
+transaction as an `OP_RETURN` output so the payment is bound to the challenge
+and cannot be reused.
+
+### 3. Retry
+
+```http
+POST /api/mcp
+X-Payment-Receipt: <txid>
+X-Payment-Nonce: <nonce>
+```
+
+Satchmo verifies the transaction pays the advertised address and amount and
+carries the matching nonce, credits the balance, marks the nonce spent, and
+runs the session. Verification is idempotent: replaying the same receipt
+credits nothing.
+
+### 4. Subsequent calls
+
+While the balance is positive the call proceeds with no challenge, decrementing
+per ask. The response reports the remaining balance so the caller can top up
+before running out.
+
+## Open question: cost of a long run
+
+An ask has unbounded cost, because a long agent run burns far more than a short
+one, and flat per-ask pricing eventually loses money on the tail. Three
+options, in the order I would try them:
+
+1. A hard turn or duration limit per ask, so the worst case is bounded and the
+   flat price holds.
+2. Metering by tokens, charging the balance proportionally.
+3. A cap per session, refunding the unused remainder.
+
+This needs a product decision before implementation, since it determines both
+the price and the balance semantics.
+
+## Work split
+
+**Satchmo (overpowered.bot), in `src/lib/mcp-server/`:** issue and verify
+challenges, keep the balance and spent-nonce records, and decrement per ask.
+That directory has an owner under the repository's `AGENTS.md`, so this needs
+coordinating with the remote-MCP worker rather than editing directly.
+
+**bsv-mcp:** an `ask` tool that calls Satchmo, catches a 402, shows the caller
+the price through the existing elicitation prompt, pays, and retries. It should
+be behind an environment flag and default off until the Satchmo side ships,
+so no wallet-spending path is live before the other end can verify it.
+
+## Prerequisite
+
+Sign-in against the hosted bsv-mcp server is currently broken for every MCP
+client, because sigma-auth refuses unauthenticated client registration. That
+blocks the identity this design keys balances on. See the note in the session
+that produced this document for the one-line fix.

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -16,6 +16,7 @@ import {
 import {
 	clients,
 	deployModes,
+	faq,
 	guarantees,
 	installCommands,
 	installTargets,
@@ -114,6 +115,10 @@ ${scopeList()}
 ## Key custody
 
 ${guarantees.map((item) => `- **${item.title}** — ${item.description}`).join("\n")}
+
+## FAQ
+
+${faq.map((item) => `**${item.q}**\n\n${item.a}`).join("\n\n")}
 
 ## More
 

--- a/lib/site-content.ts
+++ b/lib/site-content.ts
@@ -285,3 +285,75 @@ export const installTargets: InstallTarget[] = [
 		docsUrl: "https://modelcontextprotocol.io",
 	},
 ];
+
+/**
+ * Hero copy. The headline must answer "what is this" on its own; the sub
+ * carries the specifics that make it believable.
+ */
+export const hero = {
+	eyebrow: "open source",
+	headline: "The Bitcoin SV wallet for MCP clients.",
+	sub: "Tools that let Claude, Cursor or any agent send BSV, inscribe ordinals and read the chain. No SDK code. One command, hosted or local.",
+};
+
+/** Problem before solution: what an agent developer does without this. */
+export const problem = {
+	without: [
+		"Hand-wire the SDK into every agent you build",
+		"Manage keys, UTXOs and fees yourself",
+		"Re-implement broadcasting for each client",
+	],
+	with: [
+		"One MCP server, every client",
+		"Keys encrypted at rest or held by your own signer",
+		"Ask in plain language, get a txid",
+	],
+};
+
+/** The walkthrough shown as one terminal session. */
+export const replay = [
+	{
+		label: "install",
+		lines: [
+			"$ claude plugin install bsv-mcp@b-open-io",
+			"✓ bsv-mcp registered",
+		],
+	},
+	{
+		label: "ask",
+		lines: ["> inscribe hello.svg as a 1sat ordinal and tell me the txid"],
+	},
+	{
+		label: "tool call",
+		lines: [
+			'● wallet_createOrdinals(file: "hello.svg", contentType: "image/svg+xml")',
+			"  ├ reading file (412 bytes)",
+			"  ├ selecting UTXOs · fee 1 sat/kb",
+			"  └ broadcast ✓",
+		],
+	},
+	{
+		label: "result",
+		lines: ["Inscribed. Outpoint f3a1…9c2e_0 — view it on 1satordinals.com"],
+	},
+];
+
+/** The objections a developer raises before installing anything. */
+export const faq = [
+	{
+		q: "Does it work with my client?",
+		a: "Anything that speaks MCP. Claude Code, Claude Desktop, Cursor, Codex, Grok Build and opencode are documented above with their exact config; any other stdio client runs it with bunx bsv-mcp@latest.",
+	},
+	{
+		q: "Where are my keys?",
+		a: "Locally, encrypted with AES-256-GCM in the bitcoin-backup format and created with 0600 permissions. Or nowhere near this server: point it at a BRC-100 signer and that wallet stays the permission authority for every spend.",
+	},
+	{
+		q: "Is it maintained?",
+		a: "Yes. The version and protocol revision in the footer are read from the release, not typed in, and the changelog on GitHub is the record of what shipped.",
+	},
+	{
+		q: "Can I read the code first?",
+		a: "All of it. MIT licensed, on GitHub, with the tool catalogue generated from the running server so the numbers on this page cannot drift from the code.",
+	},
+];


### PR DESCRIPTION
## Summary

The previous page was a SaaS template with a colour swap, and the owner said so. This rebuilds it against the widely-cited fundamentals and the structural moves of black-and-one-accent developer sites, in BSV's actual identity: a plain ₿, yellow on black, hacker aesthetic.

## What the research said, and where it landed

Sources read in full: Julian Shapiro's landing-page handbook, Demand Curve's above-the-fold playbook, Evil Martians' study of 100 dev-tool landing pages, Corey Haines' copywriting rules, and the sites themselves (Bun, Warp, Charm, terminal.shop, SST, OpenCode, Zed, Hyper). The X threads that circulate are login-walled and were not paraphrased from memory.

- **Header passes the "only this line" test.** "The Bitcoin SV wallet for MCP clients." Category, audience and chain named; the ambiguity with BTC is gone. The technical noun is set in monospace, the Charm move.
- **Sub carries the proof**, not a second slogan: what it does, no SDK code, one command, hosted or local.
- **Install command is the first action**, copyable, above the fold, as on Bun and SST. It wraps on phones now rather than truncating mid-package-name.
- **Two CTAs, weighted**: connect the hosted server, clone source. Zed's pairing.
- **Terminal is the hero visual**, rebuilt as a Bun-style numbered replay from install to txid, with a Warp-style figure label and a blinking cursor.
- **Trust strip of numbers, not logos**, since this is an individual-oriented tool: tools, licence, clients documented, protocol revision. All derived, none typed in.
- **Problem before solution**: a without/with block naming the SDK glue nobody wants to write.
- **FAQ answers the four developer objections**: does it work with my client, where are my keys, is it maintained, can I read the code first.
- **Final CTA on a distinct yellow band** for readers who scroll to the end before deciding.

## Aesthetic

True black ground, bitcoin yellow primary with near-black text on it, plain ₿ glyph, monospace eyebrows prefixed with `#` like shell comments, path-style nav (`/tools /install /faq`), hairline borders, tighter radius, mono footer. Every colour is still a theme token.

## Also on this branch

The paid-ask proposal document under `docs/plans/`, unchanged and marked "Status: proposal". It has been displaced from three PRs by shippable work sharing this branch; merging it here ends that. It commits nothing to code.

## Verification

Screenshotted at 390px and 1280px on a production build, top of page and full page. No horizontal overflow at 390px. The four phone defects found in review are fixed: the eyebrow fits one line, the command wraps, the protocol date fits its cell, the mono span is tightened. 58 tests pass; the FAQ and replay live in `site-content` so the markdown docs render the same facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LY81VpqtH4r6JpXRTYiPG