### PR TITLE
Simplify docs and remove repeated tool definitions

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { GuideLinks } from "@/components/docs/GuideLinks";
 import { CodeSnippet } from "@/components/landing/CodeSnippet";
 import { BrcReferences } from "@/lib/brc";
 import { type DocTopic, docs } from "@/lib/docs";
@@ -126,6 +127,7 @@ export default function DocsPage() {
 					</details>
 				</aside>
 				<main className="min-w-0 max-w-3xl">
+					<GuideLinks />
 					<h1 className="text-4xl font-bold tracking-tight">Documentation</h1>
 					<p className="mb-10 mt-4 text-lg text-muted-foreground">
 						Set up the local server, connect a wallet, then ask your assistant
@@ -154,7 +156,7 @@ export default function DocsPage() {
 							className="mb-14 scroll-mt-8 space-y-4 border-t pt-8"
 						>
 							<summary className="cursor-pointer text-2xl font-semibold tracking-tight">
-								{section.title}
+								<h2 className="inline">{section.title}</h2>
 							</summary>
 							<TopicContent topic={section} />
 							{section.topics?.map((topic) => (

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -59,6 +59,10 @@ function TopicContent({ topic }: { topic: DocTopic }) {
 	);
 }
 export default function DocsPage() {
+	const orderedDocs = [
+		...docs.filter((s) => ["quickstart", "tasks"].includes(s.id)),
+		...docs.filter((s) => !["quickstart", "tasks"].includes(s.id)),
+	];
 	return (
 		<div className="mx-auto max-w-6xl px-6 pb-24">
 			<header className="flex items-center justify-between border-b py-5">
@@ -88,7 +92,7 @@ export default function DocsPage() {
 							>
 								All tools →
 							</Link>
-							{docs.map((section) => (
+							{orderedDocs.map((section) => (
 								<details key={section.id}>
 									<summary className="cursor-pointer text-sm">
 										{section.title}
@@ -142,15 +146,16 @@ export default function DocsPage() {
 							Explore all tools →
 						</Link>
 					</section>
-					{docs.map((section) => (
-						<section
+					{orderedDocs.map((section) => (
+						<details
+							open={["quickstart", "tasks"].includes(section.id)}
 							key={section.id}
 							id={section.id}
 							className="mb-14 scroll-mt-8 space-y-4 border-t pt-8"
 						>
-							<h2 className="text-2xl font-semibold tracking-tight">
+							<summary className="cursor-pointer text-2xl font-semibold tracking-tight">
 								{section.title}
-							</h2>
+							</summary>
 							<TopicContent topic={section} />
 							{section.topics?.map((topic) => (
 								<section
@@ -175,7 +180,7 @@ export default function DocsPage() {
 									))}
 								</div>
 							)}
-						</section>
+						</details>
 					))}
 				</main>
 			</div>

--- a/app/docs/tools/[name]/page.tsx
+++ b/app/docs/tools/[name]/page.tsx
@@ -6,6 +6,7 @@ import {
 	catalogTools,
 	categoryForTool,
 	compactOperations,
+	displayVariants,
 	getTool,
 	inputAlternatives,
 	inputFields,
@@ -35,6 +36,7 @@ export default async function ToolPage({ params }: Props) {
 	const category = categoryForTool(name);
 	const note = referenceNote(name);
 	const operations = compactOperations(tool);
+	const variants = displayVariants(tool);
 	const families = catalogTools.filter((t) =>
 		compactOperations(t).includes(name),
 	);
@@ -58,6 +60,14 @@ export default async function ToolPage({ params }: Props) {
 			>
 				Read as Markdown
 			</a>
+			{note.example && (
+				<section className="mt-8">
+					<h2 className="text-xl font-semibold">Example</h2>
+					<pre className="mt-3 overflow-x-auto rounded border p-4 text-sm">
+						{JSON.stringify(note.example, null, 2)}
+					</pre>
+				</section>
+			)}
 			<section className="mt-8 space-y-3">
 				<h2 className="text-xl font-semibold">Result</h2>
 				<p className="leading-7">{note.result}</p>
@@ -104,28 +114,32 @@ export default async function ToolPage({ params }: Props) {
 					in compact mode.
 				</p>
 			)}
-			{tool.variants.map((variant, index) => {
+			{variants.map((variant, index) => {
 				const fields = inputFields(variant.definition.inputSchema);
 				return (
-					<section
+					<details
+						open={index === 0}
 						key={`${variant.profile}-${variant.modes.join("-")}`}
 						className="mt-10 border-t pt-6"
 					>
-						<h2 className="text-xl font-semibold">
-							{tool.variants.length > 1
+						<summary className="cursor-pointer text-xl font-semibold">
+							{variants.length > 1
 								? `Definition ${index + 1}`
 								: "Inputs and availability"}
-						</h2>
+						</summary>
 						<p className="mt-3 text-sm leading-7">
-							<strong>
-								{variant.profile === "full"
-									? "Full catalog"
-									: "Compact catalog"}
-							</strong>{" "}
-							· {variant.modes.map(modeLabel).join("; ")}
+							<strong>{`${variant.profile} catalog`}</strong> ·{" "}
+							{variant.modes.map(modeLabel).join("; ")}
 						</p>
 						{variant.definition.description !== toolSummary(tool) && (
-							<p className="mt-3 leading-7">{variant.definition.description}</p>
+							<details className="mt-3">
+								<summary className="cursor-pointer text-sm text-muted-foreground">
+									Full tool description
+								</summary>
+								<p className="mt-3 leading-7">
+									{variant.definition.description}
+								</p>
+							</details>
 						)}
 						{!fields.length ? (
 							<p className="mt-5">No input fields. Pass an empty object.</p>
@@ -167,7 +181,7 @@ export default async function ToolPage({ params }: Props) {
 								</pre>
 							</details>
 						)}
-					</section>
+					</details>
 				);
 			})}
 		</ReferenceLayout>

--- a/app/docs/tools/page.tsx
+++ b/app/docs/tools/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ReferenceLayout } from "@/components/docs/ReferenceLayout";
-import { catalog, fullToolNames, toolNavigation } from "@/lib/tool-catalog";
+import {
+	catalog,
+	catalogTools,
+	isDeveloperTool,
+	toolNavigation,
+} from "@/lib/tool-catalog";
 
 export const metadata: Metadata = {
 	title: "All tools",
@@ -15,14 +20,11 @@ export default function ToolsPage() {
 			<p className="mb-3 font-mono text-sm text-primary">Tool reference</p>
 			<h1 className="text-4xl font-bold tracking-tight">All tools</h1>
 			<p className="mt-5 text-lg leading-8 text-muted-foreground">
-				{fullToolNames.length} full-catalog tools, plus compact families. Find a
-				tool by name or purpose, then open its inputs and wallet requirements.
+				Find a tool by what you want to do. Open its reference for inputs,
+				results and wallet requirements.
 			</p>
 			<p className="mt-4 leading-7">
-				This reference combines supported registration configurations. Your
-				running server lists only the tools enabled for its wallet, roles and
-				settings. A registered legacy tool can still require wallet setup before
-				it can run.
+				Your available tools depend on your wallet and settings.
 			</p>
 			<div className="mt-5 flex gap-5 text-sm">
 				<Link href="/docs#tasks" className="text-primary underline">
@@ -72,6 +74,28 @@ export default function ToolsPage() {
 					</ul>
 				</section>
 			))}
+			<details className="my-8 rounded border p-4">
+				<summary className="cursor-pointer font-medium">
+					Developer reference: wallet API, compact aliases and dashboard tools
+				</summary>
+				<p className="my-3">
+					Compact mode exposes a smaller set of operations and omits most write
+					tools. Wallet API tools expose low-level signing and transaction
+					methods. Dashboard tools are called by the app.
+				</p>
+				<ul className="space-y-2">
+					{catalogTools.filter(isDeveloperTool).map((t) => (
+						<li key={t.name}>
+							<Link
+								className="font-mono text-sm text-primary underline"
+								href={`/docs/tools/${t.name}`}
+							>
+								{t.name}
+							</Link>
+						</li>
+					))}
+				</ul>
+			</details>
 		</ReferenceLayout>
 	);
 }

--- a/components/docs/GuideLinks.tsx
+++ b/components/docs/GuideLinks.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+/** Expand the guide containing an existing bookmarked topic. */
+export function GuideLinks() {
+	useEffect(() => {
+		const reveal = () => {
+			let id: string;
+			try {
+				id = decodeURIComponent(window.location.hash.slice(1));
+			} catch {
+				return;
+			}
+			const target = document.getElementById(id);
+			let parent: HTMLElement | null = target;
+			while (parent) {
+				if (parent instanceof HTMLDetailsElement) parent.open = true;
+				parent = parent.parentElement;
+			}
+			target?.scrollIntoView();
+		};
+		reveal();
+		window.addEventListener("hashchange", reveal);
+		return () => window.removeEventListener("hashchange", reveal);
+	}, []);
+	return null;
+}

--- a/lib/docs.ts
+++ b/lib/docs.ts
@@ -20,8 +20,8 @@ const sections: DocSection[] = [
 		id: "quickstart",
 		title: "Start here",
 		paragraphs: [
-			"BSV MCP lets an AI assistant use Bitcoin SV tools. You can ask it to check a transaction, show your wallet balance, send a payment, or create an ordinal: content such as an image recorded on the blockchain.",
-			"Your AI client starts the server on your computer over stdio. No Sigma account or OAuth sign-in is required. Connect a wallet when you need its capabilities.",
+			"Use BSV MCP to check transactions, send payments, publish social posts and create ordinals from your AI assistant.",
+			"Your AI client runs BSV MCP on your computer. Public lookups work without a wallet. Connect one to sign or spend.",
 		],
 		links: [
 			{
@@ -37,21 +37,21 @@ const sections: DocSection[] = [
 			{
 				title: "1. Add the server",
 				paragraphs: [
-					"Install Bun to run the server and Node.js for npx, then run the command for your client in a terminal. Choose one command. The server can start before wallet setup; it never silently creates a key.",
+					"Install Bun and Node.js, then run the command for your client:",
 				],
 				code: "# Codex\ncodex mcp add bsv-mcp -- npx -y bsv-mcp@latest --stdio\n\n# Claude Code\nclaude mcp add --transport stdio bsv-mcp -- npx -y bsv-mcp@latest --stdio",
 			},
 			{
 				title: "2. Connect a wallet",
 				paragraphs: [
-					"Ask your assistant to open wallet setup. Create, import or unlock an account in the local browser, or configure an existing external wallet as described below. The server refreshes its tools after local setup.",
+					"Ask your assistant to open wallet setup. Create, import or unlock an account in the browser. To connect another wallet, open the wallet guide below.",
 				],
 			},
 			{
 				title: "3. Check the connection",
 				paragraphs: [
 					'Ask your assistant: "Run bsv_status and explain whether my wallet and 1Sat service are available."',
-					"This check reports the server configuration and contacts the 1Sat capabilities endpoint, which lists enabled API services. It does not sign transactions, spend funds, or import deposits. A successful check does not verify every wallet operation.",
+					"This checks your server and its 1Sat connection without spending funds.",
 				],
 			},
 		],
@@ -60,7 +60,7 @@ const sections: DocSection[] = [
 		id: "wallets",
 		title: "Choose your wallet",
 		paragraphs: [
-			"BSV MCP can connect to an existing wallet or manage keys locally. An existing wallet handles signing: approving a transaction with its private keys.",
+			"Connect an existing wallet or create an encrypted local account.",
 		],
 		links: [
 			{
@@ -76,7 +76,7 @@ const sections: DocSection[] = [
 			{
 				title: "Connect an existing wallet",
 				paragraphs: [
-					"Your wallet must expose the BSV SDK HTTPWalletJSON signing API. It keeps its keys and controls permissions. BSV MCP does not initialize wallet storage when connected to an external signer.",
+					"Use a wallet that supports the BSV SDK HTTPWalletJSON signing API. It keeps your keys and asks you to approve wallet operations.",
 					"Add the following variables to your MCP server environment, replace the wallet URL with your own, then restart the server. BSV_CHAIN must match the wallet network: main for mainnet or test for testnet.",
 				],
 				code: "BRC100_WALLET_URL=http://127.0.0.1:3321\nBRC100_WALLET_ORIGINATOR=bsv-mcp.local\nBSV_CHAIN=main",
@@ -120,7 +120,7 @@ const sections: DocSection[] = [
 		id: "backends",
 		title: "Configure your infrastructure",
 		paragraphs: [
-			"You can use the public services with their default settings. To run your own infrastructure, set the URLs below in the MCP server environment and restart it. Each replacement must support the same API as the service it replaces.",
+			"The default public services need no configuration. To use your own, set a compatible service URL and restart BSV MCP.",
 		],
 		links: [
 			{
@@ -178,7 +178,7 @@ const sections: DocSection[] = [
 		id: "social",
 		title: "Social",
 		paragraphs: [
-			"One reader and one publisher cover Bitcoin Schema social data. Both full and compact catalogs use the same tools. BMAP is the indexer behind reads; it is not a second social network.",
+			"Use bsocial_read to find social records and bsocial_publish to publish with your BAP identity.",
 		],
 		links: [
 			{ label: "Read tool reference", href: "/docs/tools/bsocial_read" },
@@ -225,14 +225,14 @@ const sections: DocSection[] = [
 		id: "tasks",
 		title: "Common tasks",
 		paragraphs: [
-			"Ask your assistant for the task you want to complete. The tool names below help you check what it is calling. Open the tool reference for exact inputs, results and wallet requirements.",
+			"Ask your assistant for what you want. These examples show which tools it can use.",
 		],
 		topics: [
 			{
 				title: "Check your balance or a transaction",
 				paragraphs: [
 					'Ask: "Show my BSV balance and the ordinals in my wallet."',
-					"wallet_getBalance reports funds. wallet_getOrdinals lists ordinals, wallet_getBsv21Balances reports token balances, and wallet_getLockData reports locked funds.",
+					"Use wallet_getBalance for BSV, wallet_getOrdinals for inscriptions, wallet_getBsv21Balances for token balances, and wallet_getLockData for locked funds.",
 					"To inspect the blockchain, use bsv_explore for addresses, blocks, and transactions. bsv_decodeTransaction reads a transaction ID or transaction data encoded as hex or base64.",
 				],
 			},
@@ -240,7 +240,7 @@ const sections: DocSection[] = [
 				title: "Receive a payment",
 				paragraphs: [
 					'Ask: "Give me a deposit address, then check for incoming funds."',
-					"wallet_getAddress returns the deposit address. After the payment arrives, wallet_refreshUtxos imports deposits found by the blockchain indexer into the wallet. The indexer is the service that tracks blockchain activity. Your wallet balance may lag behind the on-chain balance until indexing and import finish.",
+					"wallet_getAddress returns the deposit address. After the payment arrives, wallet_refreshUtxos imports deposits found by the blockchain indexer into the wallet. Your wallet balance may lag behind the on-chain balance until indexing and import finish.",
 				],
 			},
 			{
@@ -280,7 +280,7 @@ const sections: DocSection[] = [
 				title: "Enable or disable tool groups",
 				paragraphs: [
 					"Disable a tool group when an assistant should not have it in its catalog. Broadcasting controls block guarded transaction submissions; they do not replace the connected wallet’s permissions.",
-					"External signer mode supports context wallet and BRC-100 tools. Legacy collection minting/gathering, BAP/raw-key, BSocial and MNEE tools are unavailable in that mode. An advertised backend module does not automatically enable a tool group.",
+					"External signer mode supports context wallet and BRC-100 tools. Legacy collection minting/gathering, raw-key BAP and MNEE tools are unavailable in that mode. Public social reads are available; social publishing is currently unavailable with an external signer. An advertised backend module does not automatically enable a tool group.",
 				],
 			},
 			{
@@ -296,8 +296,8 @@ const sections: DocSection[] = [
 		id: "x402",
 		title: "Pay for an online service",
 		paragraphs: [
-			"BSV MCP can request a service, read its price, and pay with the connected wallet after you authorize the purchase. The service can be a paid API, a file download, an agent, or an account upgrade. x402 itself does not require an API key.",
-			"The client takes the service URL and request details directly. There is no default vendor or required payment account. Services that separately require authentication can use wallet identity or optional service credentials.",
+			"Use x402_request to get a service response or price quote. After you approve the price, x402_payQuote pays with your connected wallet.",
+			"Supply the service URL. Some services also need wallet authentication or an API key.",
 		],
 		topics: [
 			{
@@ -362,7 +362,7 @@ const sections: DocSection[] = [
 		id: "sponsorship",
 		title: "Use a sponsor",
 		paragraphs: [
-			"A Droplit sponsor can provide funding or pay for supported operations, subject to its approval and quotas. Being listed in the sponsor catalog does not guarantee funding.",
+			"A Droplit sponsor can fund supported operations after approving your access. Its quotas and available funds apply.",
 		],
 		topics: [
 			{
@@ -439,7 +439,7 @@ const sections: DocSection[] = [
 		id: "development",
 		title: "Development",
 		paragraphs: [
-			"This project is experimental. For development, use Bun and the commands below. The tool reference combines registration fixtures for local, external and sponsored wallets in full and compact mode. Run bun run tools:manifest after changing tool registration. Captures use isolated processes without local keys or network calls.",
+			"Use Bun for development. After changing tool registration, run bun run tools:manifest to update the reference from isolated registration captures.",
 		],
 		code: "bun install\nbun run dev          # Website\nbun run build:all    # MCP server + dashboard\nbun run build:next   # Production website\nbun test             # Includes server-start integration checks\nbun run lint",
 		links: [

--- a/lib/tool-catalog.ts
+++ b/lib/tool-catalog.ts
@@ -1,5 +1,6 @@
 import { toolCategories } from "./site-content";
 import data from "./tool-catalog.json";
+import { toolReferenceNotes, walletRPC } from "./tool-reference-notes";
 
 export interface JsonSchema {
 	[key: string]: unknown;
@@ -49,7 +50,11 @@ export function categoryForTool(name: string) {
 	);
 }
 export function toolSummary(tool: ToolEntry) {
-	return tool.variants[0].definition.description ?? tool.name;
+	return (
+		toolReferenceNotes[tool.name]?.summary ??
+		tool.variants[0].definition.description?.split(". ")[0] ??
+		tool.name
+	);
 }
 export function compactOperations(tool: ToolEntry): string[] {
 	return [
@@ -119,11 +124,41 @@ export function inputFields(schema: JsonSchema, prefix = ""): InputField[] {
 		];
 	});
 }
+export function displayVariants(tool: ToolEntry) {
+	const variants: {
+		definition: ToolDefinition;
+		modes: string[];
+		profile: string;
+	}[] = [];
+	for (const variant of tool.variants) {
+		const existing = variants.find(
+			(v) =>
+				JSON.stringify(v.definition) === JSON.stringify(variant.definition),
+		);
+		if (existing) {
+			existing.modes = [...new Set([...existing.modes, ...variant.modes])];
+			existing.profile = "full and compact";
+		} else variants.push({ ...variant, modes: [...variant.modes] });
+	}
+	return variants;
+}
+export function isDeveloperTool(tool: ToolEntry) {
+	return (
+		tool.name.startsWith("app_") ||
+		tool.variants.every((v) => v.profile === "compact") ||
+		[...walletRPC, "createAction", "signAction", "abortAction"].some(
+			(method) => tool.name === `wallet_${method}`,
+		)
+	);
+}
 export const toolNavigation = toolCategories.map((category) => ({
 	id: category.key,
 	name: category.name,
 	tools: catalogTools
-		.filter((t) => categoryForTool(t.name)?.key === category.key)
+		.filter(
+			(t) =>
+				categoryForTool(t.name)?.key === category.key && !isDeveloperTool(t),
+		)
 		.map((tool) => ({
 			name: tool.name,
 			description: toolSummary(tool),

--- a/lib/tool-reference-markdown.ts
+++ b/lib/tool-reference-markdown.ts
@@ -2,9 +2,11 @@ import { SITE_URL } from "./site";
 import {
 	catalogTools,
 	compactOperations,
+	displayVariants,
 	getTool,
 	inputAlternatives,
 	inputFields,
+	isDeveloperTool,
 	modeLabel,
 	toolNavigation,
 	toolSummary,
@@ -13,7 +15,10 @@ import { referenceNote } from "./tool-reference-notes";
 
 const cell = (value: string) => value.replace(/\|/g, "\\|").replace(/\n/g, " ");
 export function renderToolIndexMarkdown(): string {
-	return `# BSV MCP tool reference\n\nThis catalog combines supported wallet configurations. Your server lists only enabled tools.\n\n${toolNavigation.map((group) => `## ${group.name}\n\n${group.tools.map((tool) => `- [${tool.name}](${SITE_URL}/docs/tools/${tool.name}): ${tool.description}`).join("\n")}`).join("\n\n")}`;
+	return `# BSV MCP tool reference\n\nThis catalog combines supported wallet configurations. Your server lists only enabled tools.\n\n${toolNavigation.map((group) => `## ${group.name}\n\n${group.tools.map((tool) => `- [${tool.name}](${SITE_URL}/docs/tools/${tool.name}): ${tool.description}`).join("\n")}`).join("\n\n")}\n\n## Developer reference\n\n${catalogTools
+		.filter(isDeveloperTool)
+		.map((t) => `- [${t.name}](${SITE_URL}/docs/tools/${t.name})`)
+		.join("\n")}`;
 }
 export function renderToolMarkdown(name: string): string | undefined {
 	const tool = getTool(name);
@@ -23,6 +28,11 @@ export function renderToolMarkdown(name: string): string | undefined {
 	return [
 		`# ${name}`,
 		toolSummary(tool),
+		...(note.example
+			? [
+					`## Example\n\n\`\`\`json\n${JSON.stringify(note.example, null, 2)}\n\`\`\``,
+				]
+			: []),
 		`## Result\n\n${note.result}`,
 		`## Permissions\n\n${note.approval}`,
 		...(note.details ? [note.details] : []),
@@ -31,7 +41,7 @@ export function renderToolMarkdown(name: string): string | undefined {
 					`## Compact operations\n\nPass the full tool name as operation and its inputs as args.\n\n${operations.map((op) => `- [${op}](${SITE_URL}/docs/tools/${op})`).join("\n")}`,
 				]
 			: []),
-		...tool.variants.map((variant, index) => {
+		...displayVariants(tool).map((variant, index) => {
 			const fields = inputFields(variant.definition.inputSchema);
 			return [
 				`## Definition ${index + 1} (${variant.profile})`,

--- a/lib/tool-reference-notes.ts
+++ b/lib/tool-reference-notes.ts
@@ -1,18 +1,31 @@
 /** Editorial details checked against the tool handlers; never inferred from readOnlyHint. */
 export interface ReferenceNote {
+	summary?: string;
+	example?: Record<string, unknown>;
 	result: string;
 	approval: string;
 	details?: string;
 }
 export const toolReferenceNotes: Record<string, ReferenceNote> = {
 	bsocial_read: {
-		result:
-			"Structured source, operation and indexer data, also returned as JSON text.",
+		example: { query: { type: "search", q: "bitcoin", limit: 10 } },
+		summary: "Read posts, conversations, reactions and social history.",
+		result: "Returns the requested social records and their indexer source.",
 		approval: "Public read; no wallet or signing permission required.",
 		details:
 			"Choose query.type. records reads raw action history, including follow/unfollow; it does not claim current relationship state or independently verified authorship. PUBLIC_BMAP_URL is the server root exposing /social and /q routes. Messages are not decrypted.",
 	},
 	bsocial_publish: {
+		example: {
+			action: {
+				type: "post",
+				content: "Hello Bitcoin",
+				contentType: "text/plain",
+			},
+			preview: true,
+		},
+		summary:
+			"Publish a post, reply, reaction or message with your BAP identity.",
 		result:
 			"Transaction ID, action type and output count; preview returns unsigned output scripts without spending.",
 		approval:
@@ -109,7 +122,7 @@ export const toolReferenceNotes: Record<string, ReferenceNote> = {
 	},
 };
 
-const walletRPC = [
+export const walletRPC = [
 	"getPublicKey",
 	"encrypt",
 	"decrypt",
@@ -142,7 +155,7 @@ for (const method of walletRPC)
 		approval:
 			"Forwarded to the connected wallet under the configured app origin. Its protocol, certificate or basket permission checks apply to the requested operation.",
 		details:
-			"In role-routed configurations, walletRole selects an assigned wallet. Identity methods default to the identity role; encryption and HMAC use the encryption role. Transaction and basket operations follow their assigned role. An unavailable role fails rather than borrowing another key.",
+			"Use walletRole to choose an assigned wallet. Otherwise the configured role is used. A disabled role cannot borrow another key.",
 	};
 const publicReads: Record<string, string> = {
 	bsv_dashboard: "The MCP dashboard app resource and its initial view state.",
@@ -177,8 +190,7 @@ const publicReads: Record<string, string> = {
 for (const [name, result] of Object.entries(publicReads))
 	toolReferenceNotes[name] = {
 		result,
-		approval:
-			"No spending approval is requested by this handler. Public network lookups can still fail or require a compatible service.",
+		approval: "No wallet required.",
 	};
 const contextReads: Record<string, string> = {
 	app_wallet_data: "Wallet data for the selected dashboard view.",
@@ -190,7 +202,8 @@ const contextReads: Record<string, string> = {
 	wallet_getBalance:
 		"Local balance in satoshis and BSV with a UTXO count, or the sponsored balance in Droplit mode.",
 	wallet_getOrdinals: "The ordinals listing result as JSON text.",
-	wallet_listTokens: "The BSV21 token listing result as JSON text.",
+	wallet_listTokens:
+		"Individual BSV21 token outputs. For totals by token, use wallet_getBsv21Balances.",
 	wallet_getBsv21Balances: "BSV21 balances as JSON text.",
 	wallet_getLockData: "Locked-output data as JSON text.",
 	bap_getIdentity:

--- a/lib/tool-reference.test.ts
+++ b/lib/tool-reference.test.ts
@@ -90,3 +90,23 @@ test("social operations expose their conditional fields in the reference", () =>
 		"action.attachments[].contentType",
 	);
 });
+
+test("reader reference deduplicates profiles without hiding distinct wallet inputs", async () => {
+	const { displayVariants, toolNavigation } = await import("./tool-catalog");
+	for (const name of ["bsocial_read", "bsocial_publish"]) {
+		const tool = getTool(name);
+		if (!tool) throw new Error(`Missing ${name}`);
+		expect(displayVariants(tool)).toHaveLength(1);
+		expect(renderToolMarkdown(name)?.match(/^## Definition/gm)).toHaveLength(1);
+	}
+	const publicKey = getTool("wallet_getPublicKey");
+	if (!publicKey) throw new Error("Missing public key tool");
+	expect(displayVariants(publicKey)).toHaveLength(2);
+	const navigation = toolNavigation.flatMap((group) =>
+		group.tools.map((tool) => tool.name),
+	);
+	expect(navigation).toContain("bsocial_publish");
+	expect(navigation).not.toContain("app_wallet_data");
+	expect(navigation).not.toContain("wallet_setup");
+	expect(renderToolMarkdown("app_wallet_data")).toBeDefined();
+});


### PR DESCRIPTION
The docs exposed every wallet configuration, compact alias and dashboard helper in the main reading path. Show shared tool definitions once, put low-level wallet API and app tools in a developer reference, and lead the guide with setup and common tasks. Shorten introductions, add social examples, and correct external-wallet social availability.

Existing tool names, handlers and registration data are unchanged. HTML and Markdown share deduplicated definitions and retain developer reference links. Validation: focused documentation/catalog tests, TypeScript, production build, and browser checks.
