### PR TITLE
Fix Vault setup unlock, import remapping, and form controls

### DIFF
--- a/src/views/components/FormFields.tsx
+++ b/src/views/components/FormFields.tsx
@@ -1,0 +1,163 @@
+import { Eye, EyeOff } from "lucide-react";
+import {
+	type InputHTMLAttributes,
+	type ReactNode,
+	type SelectHTMLAttributes,
+	useId,
+	useState,
+} from "react";
+
+export function Field({
+	label,
+	htmlFor,
+	hint,
+	error,
+	children,
+}: {
+	label: ReactNode;
+	htmlFor?: string;
+	hint?: ReactNode;
+	error?: ReactNode;
+	children: ReactNode;
+}) {
+	return (
+		<div className="field-group">
+			{htmlFor ? (
+				<label className="field-label" htmlFor={htmlFor}>
+					{label}
+				</label>
+			) : (
+				<span className="field-label">{label}</span>
+			)}
+			{children}
+			{error ? (
+				<p className="field-error" role="alert">
+					{error}
+				</p>
+			) : hint ? (
+				<p className="field-hint">{hint}</p>
+			) : null}
+		</div>
+	);
+}
+
+export function TextInput({
+	className,
+	...props
+}: InputHTMLAttributes<HTMLInputElement>) {
+	return (
+		<input className={className ? `field ${className}` : "field"} {...props} />
+	);
+}
+
+export function PasswordInput({
+	id,
+	value,
+	onValueChange,
+	disabled,
+	autoComplete,
+	required,
+	minLength,
+	name,
+	"aria-invalid": ariaInvalid,
+	"aria-describedby": ariaDescribedBy,
+	"aria-label": ariaLabel,
+	onKeyDown,
+}: {
+	id?: string;
+	value: string;
+	onValueChange: (value: string) => void;
+	disabled?: boolean;
+	autoComplete?: string;
+	required?: boolean;
+	minLength?: number;
+	name?: string;
+	"aria-invalid"?: boolean;
+	"aria-describedby"?: string;
+	"aria-label"?: string;
+	onKeyDown?: InputHTMLAttributes<HTMLInputElement>["onKeyDown"];
+}) {
+	const [visible, setVisible] = useState(false);
+	return (
+		<div className="password-field">
+			<input
+				id={id}
+				name={name}
+				className="field hide-password-toggle"
+				type={visible ? "text" : "password"}
+				value={value}
+				onChange={(event) => onValueChange(event.target.value)}
+				disabled={disabled}
+				autoComplete={autoComplete}
+				required={required}
+				minLength={minLength}
+				spellCheck={false}
+				aria-invalid={ariaInvalid}
+				aria-describedby={ariaDescribedBy}
+				aria-label={ariaLabel}
+				onKeyDown={onKeyDown}
+			/>
+			<button
+				type="button"
+				className="password-toggle"
+				onClick={() => setVisible((current) => !current)}
+				disabled={disabled}
+				aria-label={visible ? "Hide password" : "Show password"}
+				aria-pressed={visible}
+			>
+				{visible ? (
+					<EyeOff size={18} aria-hidden="true" />
+				) : (
+					<Eye size={18} aria-hidden="true" />
+				)}
+			</button>
+		</div>
+	);
+}
+
+export function CheckboxField({
+	id,
+	checked,
+	onCheckedChange,
+	disabled,
+	required,
+	children,
+}: {
+	id?: string;
+	checked: boolean;
+	onCheckedChange: (checked: boolean) => void;
+	disabled?: boolean;
+	required?: boolean;
+	children: ReactNode;
+}) {
+	const generatedId = useId();
+	const inputId = id ?? generatedId;
+	return (
+		<div className="checkbox-field">
+			<input
+				id={inputId}
+				className="checkbox-control"
+				type="checkbox"
+				checked={checked}
+				onChange={(event) => onCheckedChange(event.target.checked)}
+				disabled={disabled}
+				required={required}
+			/>
+			<label className="checkbox-label" htmlFor={inputId}>
+				{children}
+			</label>
+		</div>
+	);
+}
+
+export function SelectInput({
+	className,
+	children,
+	...props
+}: SelectHTMLAttributes<HTMLSelectElement>) {
+	return (
+		<select className={className ? `select ${className}` : "select"} {...props}>
+			{children}
+		</select>
+	);
+}

--- a/src/views/features/Dashboard.tsx
+++ b/src/views/features/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { P2PKH, PrivateKey, Transaction, Utils } from "@bsv/sdk";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Field, PasswordInput } from "../components/FormFields";
 import {
 	Button,
 	DataRow,
@@ -716,23 +717,19 @@ function Sweep({ call }: { call: Caller }) {
 				</div>
 				<div className="surface-body">
 					{state === "input" || state === "error" ? (
-						<>
-							<label className="field-label" htmlFor="sweep-key">
-								WIF or 64-character hex
-								<input
+						<div className="form-stack">
+							<Field label="WIF or 64-character hex" htmlFor="sweep-key">
+								<PasswordInput
 									id="sweep-key"
-									className="field"
-									type="password"
 									value={keyInput}
-									onChange={(event) => setKeyInput(event.target.value)}
+									onValueChange={setKeyInput}
+									autoComplete="off"
 									onKeyDown={(event) => {
 										if (event.key === "Enter") void scanKey();
 									}}
-									autoComplete="new-password"
-									spellCheck={false}
 								/>
-							</label>
-							<p className="dim">
+							</Field>
+							<p className="field-hint">
 								The key is used only in this tab and cleared after scanning or
 								sweeping.
 							</p>
@@ -744,7 +741,7 @@ function Sweep({ call }: { call: Caller }) {
 									Scan address
 								</Button>
 							</div>
-						</>
+						</div>
 					) : null}
 					{state === "scanning" || state === "working" ? (
 						<Spinner

--- a/src/views/features/ExistingWallet.tsx
+++ b/src/views/features/ExistingWallet.tsx
@@ -3,6 +3,12 @@ import type { MigrationSource } from "../../../utils/vaultMigration";
 import type { AvailableSetupTool } from "../../../utils/vaultSetup";
 import { AvailableTools } from "../components/AvailableTools";
 import {
+	CheckboxField,
+	Field,
+	PasswordInput,
+	TextInput,
+} from "../components/FormFields";
+import {
 	Button,
 	LocalShell,
 	Notice,
@@ -11,6 +17,7 @@ import {
 } from "../components/LocalShell";
 import { WalletReady } from "../components/WalletReady";
 import { migrationSourceCopy } from "../lib/migrationLabels";
+import { friendlySetupError, unusedAccountName } from "../lib/setupCopy";
 import { vaultPasswordIssue } from "../lib/vaultPassphrase";
 
 export function ExistingWallet({
@@ -42,6 +49,12 @@ export function ExistingWallet({
 	const [inventoryRevision, setInventoryRevision] = useState(0);
 	const [error, setError] = useState("");
 	const [tools, setTools] = useState<AvailableSetupTool[]>();
+	const takenNames = boundAccounts.map((account) => account.name);
+	const remapped =
+		Boolean(source) &&
+		source !== undefined &&
+		takenNames.includes(source.account) &&
+		accountName !== source.account;
 	useEffect(() => {
 		if (!token) return;
 		fetch(`/api/inventory?revision=${inventoryRevision}`, {
@@ -76,6 +89,17 @@ export function ExistingWallet({
 		setSourcePassphrase("");
 		setDestinationPassphrase("");
 		setPasswordConfirmation("");
+		setError("");
+	}
+	function chooseSource(item: MigrationSource) {
+		setSource(item);
+		setFile(undefined);
+		setAccountName(
+			unusedAccountName(
+				item.account,
+				boundAccounts.map((account) => account.name),
+			),
+		);
 		setError("");
 	}
 	async function submit(event: FormEvent) {
@@ -137,9 +161,12 @@ export function ExistingWallet({
 			setReady(true);
 		} catch (reason) {
 			setError(
-				reason instanceof Error
-					? reason.message
-					: "The wallet could not be imported.",
+				friendlySetupError(
+					reason instanceof Error
+						? reason.message
+						: "The wallet could not be imported.",
+					accountName,
+				),
 			);
 		} finally {
 			setPending(false);
@@ -171,13 +198,13 @@ export function ExistingWallet({
 						: "Choose a wallet found on this computer, or browse for a key backup."
 				}
 			/>
-			{error && <Notice tone="error">{error}</Notice>}
-			{savedAccount && (
+			{error ? <Notice tone="error">{error}</Notice> : null}
+			{savedAccount ? (
 				<Notice tone="success">
 					{savedAccount} is saved in your Vault. Import another wallet below, or
 					choose your default keys to continue.
 				</Notice>
-			)}
+			) : null}
 			{ready ? (
 				<>
 					<Notice tone="success">
@@ -189,54 +216,51 @@ export function ExistingWallet({
 				</>
 			) : !source && !file ? (
 				<Surface>
-					<div className="surface-body">
+					<div className="surface-body form-stack">
 						<h2>Choose your wallet</h2>
-						{boundAccounts.map((account) => (
-							<button
-								className="setup-choice wallet-source-choice"
-								type="button"
-								key={account.name}
-								onClick={() => onUnlock(account.name)}
-							>
-								<strong>{account.name}</strong>
-								<span>Saved in your Vault · choose default keys</span>
-							</button>
-						))}
-						{sources === undefined ? (
-							<p>Looking for local wallets…</p>
-						) : sources.length === 0 ? (
-							<p>
-								No additional local wallets were found. You can choose a backup
-								below.
-							</p>
-						) : (
-							sources.map((item) => {
-								const copy = migrationSourceCopy(item);
-								return (
-									<button
-										key={`${item.location}:${item.account}`}
-										type="button"
-										className="setup-choice wallet-source-choice"
-										onClick={() => {
-											setSource(item);
-											setAccountName(item.account);
-											setError("");
-										}}
-									>
-										<strong>{copy.title}</strong>
-										<span>{copy.origin}</span>
-										<span>{copy.detail}</span>
-										{(item.configPath || item.directory) && (
-											<span>{item.configPath || item.directory}</span>
-										)}
-									</button>
-								);
-							})
-						)}
-						<label className="field-label">
-							Browse for a key backup
-							<input
-								className="field"
+						<div className="choice-stack">
+							{boundAccounts.map((account) => (
+								<button
+									className="setup-choice wallet-source-choice"
+									type="button"
+									key={account.name}
+									onClick={() => onUnlock(account.name)}
+								>
+									<strong>{account.name}</strong>
+									<span>Saved in your Vault · choose default keys</span>
+								</button>
+							))}
+							{sources === undefined ? (
+								<p>Looking for local wallets…</p>
+							) : sources.length === 0 ? (
+								<p>
+									No additional local wallets were found. You can choose a
+									backup below.
+								</p>
+							) : (
+								sources.map((item) => {
+									const copy = migrationSourceCopy(item);
+									return (
+										<button
+											key={`${item.location}:${item.account}`}
+											type="button"
+											className="setup-choice wallet-source-choice"
+											onClick={() => chooseSource(item)}
+										>
+											<strong>{copy.title}</strong>
+											<span>{copy.origin}</span>
+											<span>{copy.detail}</span>
+											{(item.configPath || item.directory) && (
+												<span>{item.configPath || item.directory}</span>
+											)}
+										</button>
+									);
+								})
+							)}
+						</div>
+						<Field label="Browse for a key backup" htmlFor="key-backup">
+							<TextInput
+								id="key-backup"
 								type="file"
 								disabled={pending}
 								accept=".bep,.json"
@@ -246,112 +270,116 @@ export function ExistingWallet({
 									setError("");
 								}}
 							/>
-						</label>
-						<Button variant="secondary" onClick={onWelcome}>
-							Back
-						</Button>
+						</Field>
+						<div className="form-actions">
+							<Button variant="secondary" onClick={onWelcome}>
+								Back
+							</Button>
+						</div>
 					</div>
 				</Surface>
 			) : (
 				<Surface>
-					<div className="surface-body">
+					<div className="surface-body form-stack">
 						<h2>Protect and import</h2>
 						<p>{file?.name || source?.account}</p>
-						{source && !source.encryptedBackup && !source.plaintextKeys && (
+						{source && !source.encryptedBackup && !source.plaintextKeys ? (
 							<Notice>
 								These databases contain wallet records. Select the matching key
 								backup to recover signing access.
 							</Notice>
-						)}
-						<form className="stack-surface" onSubmit={submit}>
-							{source && !source.encryptedBackup && !source.plaintextKeys && (
-								<label className="field-label">
-									Matching key backup
-									<input
-										className="field"
+						) : null}
+						{remapped ? (
+							<Notice>
+								A wallet named {source?.account} is already saved. These keys
+								will be imported as {accountName}.
+							</Notice>
+						) : null}
+						<form className="form-stack" onSubmit={submit}>
+							{source && !source.encryptedBackup && !source.plaintextKeys ? (
+								<Field label="Matching key backup" htmlFor="matching-backup">
+									<TextInput
+										id="matching-backup"
 										required
 										type="file"
 										disabled={pending}
 										accept=".bep,.json"
 										onChange={(event) => setFile(event.target.files?.[0])}
 									/>
-								</label>
-							)}
-							<label className="field-label">
-								Wallet name
-								<input
-									className="field"
+								</Field>
+							) : null}
+							<Field
+								label="Wallet name"
+								htmlFor="import-wallet-name"
+								hint="Use a new name if this wallet is already saved under a different key."
+							>
+								<TextInput
+									id="import-wallet-name"
 									required
 									value={accountName}
 									onChange={(event) => setAccountName(event.target.value)}
-									disabled={pending || !!source}
+									disabled={pending}
+									autoComplete="off"
+									pattern="[a-z0-9][a-z0-9_-]{0,63}"
 								/>
-							</label>
-							<label className="field-label">
-								Backup password, if encrypted
-								<input
-									className="field"
-									type="password"
+							</Field>
+							<Field
+								label="Backup password, if encrypted"
+								htmlFor="backup-password"
+							>
+								<PasswordInput
+									id="backup-password"
 									autoComplete="off"
 									value={sourcePassphrase}
-									onChange={(event) => setSourcePassphrase(event.target.value)}
+									onValueChange={setSourcePassphrase}
 									disabled={pending}
 								/>
-							</label>
-							<label className="field-label">
-								Vault password
-								<input
-									className="field"
+							</Field>
+							<Field
+								label="Vault password"
+								htmlFor="vault-password"
+								hint="Use your existing Vault password, or choose one if this is your first wallet."
+							>
+								<PasswordInput
+									id="vault-password"
 									required
-									type="password"
 									autoComplete="new-password"
 									minLength={8}
 									value={destinationPassphrase}
-									onChange={(event) =>
-										setDestinationPassphrase(event.target.value)
-									}
+									onValueChange={setDestinationPassphrase}
 									disabled={pending}
 								/>
-							</label>
-							<p>
-								Use your existing Vault password, or choose one if this is your
-								first wallet.
-							</p>
-							<label className="field-label">
-								Confirm Vault password
-								<input
-									className="field"
+							</Field>
+							<Field
+								label="Confirm Vault password"
+								htmlFor="vault-password-confirm"
+							>
+								<PasswordInput
+									id="vault-password-confirm"
 									required
-									type="password"
 									autoComplete="new-password"
 									value={passwordConfirmation}
-									onChange={(event) =>
-										setPasswordConfirmation(event.target.value)
-									}
+									onValueChange={setPasswordConfirmation}
 									disabled={pending}
 								/>
-							</label>
-							<label className="checkbox-field">
-								<input
-									required
-									type="checkbox"
-									checked={confirmed}
-									onChange={(event) => setConfirmed(event.target.checked)}
-									disabled={pending}
-								/>{" "}
+							</Field>
+							<CheckboxField
+								checked={confirmed}
+								onCheckedChange={setConfirmed}
+								required
+								disabled={pending}
+							>
 								Import this wallet into my local encrypted Vault.
-							</label>
+							</CheckboxField>
 							{source?.plaintextKeys || source?.location === "mcp-client" ? (
-								<label className="checkbox-field">
-									<input
-										type="checkbox"
-										checked={eraseSources}
-										onChange={(event) => setEraseSources(event.target.checked)}
-										disabled={pending}
-									/>{" "}
+								<CheckboxField
+									checked={eraseSources}
+									onCheckedChange={setEraseSources}
+									disabled={pending}
+								>
 									After import, overwrite and remove the plaintext copy that was
 									imported. This cannot erase SSD snapshots or other backups.
-								</label>
+								</CheckboxField>
 							) : null}
 							<div className="form-actions">
 								<Button

--- a/src/views/features/FirstRun.tsx
+++ b/src/views/features/FirstRun.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useEffect, useState } from "react";
 import type { AvailableSetupTool } from "../../../utils/vaultSetup";
 import { AvailableTools } from "../components/AvailableTools";
+import { Field, PasswordInput, TextInput } from "../components/FormFields";
 import {
 	Button,
 	LocalShell,
@@ -9,6 +10,7 @@ import {
 	Surface,
 } from "../components/LocalShell";
 import { WalletReady } from "../components/WalletReady";
+import { friendlySetupError } from "../lib/setupCopy";
 import { vaultPasswordIssue } from "../lib/vaultPassphrase";
 import { ExistingWallet } from "./ExistingWallet";
 import { WalletRoleSettings } from "./WalletRoleSettings";
@@ -27,6 +29,7 @@ export function FirstRun({
 		[],
 	);
 	const [name, setName] = useState("default");
+	const [preferredAccount, setPreferredAccount] = useState<string>();
 	const [password, setPassword] = useState("");
 	const [confirmation, setConfirmation] = useState("");
 	const [pending, setPending] = useState(false);
@@ -95,7 +98,20 @@ export function FirstRun({
 		setPassword("");
 		setConfirmation("");
 		setError("");
+		if (choice === "unlock") {
+			navigate("roles");
+			return;
+		}
 		navigate("welcome");
+	}
+	function rememberAccount(account: string) {
+		setName(account);
+		setPreferredAccount(account);
+		setBoundAccounts((current) =>
+			current.some((item) => item.name === account)
+				? current
+				: [...current, { name: account }],
+		);
 	}
 	async function create(event: FormEvent) {
 		event.preventDefault();
@@ -144,6 +160,7 @@ export function FirstRun({
 			setPassword("");
 			setConfirmation("");
 			if (value.saved === true) {
+				rememberAccount(name);
 				setChoice("roles");
 				window.history.pushState(
 					{ view: "roles" },
@@ -160,9 +177,12 @@ export function FirstRun({
 			setCreated(true);
 		} catch (reason) {
 			setError(
-				reason instanceof Error
-					? reason.message
-					: "Your wallet could not be created.",
+				friendlySetupError(
+					reason instanceof Error
+						? reason.message
+						: "Your wallet could not be created.",
+					name,
+				),
 			);
 		} finally {
 			setPending(false);
@@ -182,9 +202,10 @@ export function FirstRun({
 		return (
 			<WalletRoleSettings
 				token={token}
+				preferredAccount={preferredAccount}
 				onBack={() => navigate("existing")}
 				onUnlock={(account) => {
-					setName(account);
+					rememberAccount(account);
 					navigate("unlock");
 				}}
 			/>
@@ -195,7 +216,10 @@ export function FirstRun({
 				token={token}
 				standalone={standalone}
 				onWelcome={back}
-				onUnlock={() => navigate("roles")}
+				onUnlock={(account) => {
+					rememberAccount(account);
+					navigate("roles");
+				}}
 			/>
 		);
 	if (created && !standalone)
@@ -301,12 +325,18 @@ export function FirstRun({
 				</div>
 			) : (
 				<Surface>
-					<form className="surface-body" onSubmit={create}>
-						<label className="field-label" htmlFor="wallet-name">
-							Wallet name
-							<input
+					<form className="surface-body form-stack" onSubmit={create}>
+						<Field
+							label="Wallet name"
+							htmlFor="wallet-name"
+							hint={
+								choice === "unlock"
+									? "This is the payment key you chose. Go back to pick a different wallet."
+									: undefined
+							}
+						>
+							<TextInput
 								id="wallet-name"
-								className="field"
 								value={name}
 								onChange={(event) => setName(event.target.value)}
 								autoComplete="off"
@@ -314,46 +344,45 @@ export function FirstRun({
 								required
 								disabled={pending || choice === "unlock"}
 							/>
-						</label>
-						<label className="field-label" htmlFor="new-password">
-							Password
-							<input
+						</Field>
+						<Field
+							label="Password"
+							htmlFor="new-password"
+							hint={
+								choice === "unlock"
+									? "Use the password for your existing Vault."
+									: vaultExists
+										? "Use the password for your existing Vault."
+										: "Use at least 12 characters, or 16+ as a passphrase. On this Mac, Touch ID can wrap the Vault as well. Keep the recovery password somewhere safe."
+							}
+						>
+							<PasswordInput
 								id="new-password"
-								className="field"
-								type="password"
 								value={password}
-								onChange={(event) => setPassword(event.target.value)}
-								autoComplete="new-password"
-								minLength={8}
+								onValueChange={setPassword}
+								autoComplete={
+									choice === "unlock" ? "current-password" : "new-password"
+								}
+								minLength={choice === "unlock" ? undefined : 8}
 								required
 								disabled={pending}
+								aria-invalid={Boolean(error)}
 							/>
-							<span className="source-detail">
-								{vaultExists
-									? "Use the password for your existing Vault."
-									: "Use at least 12 characters, or 16+ as a passphrase. On this Mac, Touch ID can wrap the Vault as well. Keep the recovery password somewhere safe."}
-							</span>
-						</label>
+						</Field>
 						{choice !== "unlock" && (
-							<label className="field-label" htmlFor="confirm-password">
-								Confirm password
-								<input
+							<Field label="Confirm password" htmlFor="confirm-password">
+								<PasswordInput
 									id="confirm-password"
-									className="field"
-									type="password"
 									value={confirmation}
-									onChange={(event) => setConfirmation(event.target.value)}
+									onValueChange={setConfirmation}
 									autoComplete="new-password"
 									required
 									disabled={pending}
+									aria-invalid={Boolean(error)}
 								/>
-							</label>
+							</Field>
 						)}
-						{error ? (
-							<div className="stack-surface">
-								<Notice tone="error">{error}</Notice>
-							</div>
-						) : null}
+						{error ? <Notice tone="error">{error}</Notice> : null}
 						<div className="form-actions">
 							<Button variant="secondary" onClick={back} disabled={pending}>
 								Back

--- a/src/views/features/Migration.tsx
+++ b/src/views/features/Migration.tsx
@@ -15,6 +15,7 @@ import {
 	type ProjectRoleSelectionRequest,
 	type VaultMigrationDestination,
 } from "../../../utils/vaultMigrationWizard";
+import { Field, PasswordInput, TextInput } from "../components/FormFields";
 import {
 	Button,
 	LocalShell,
@@ -420,7 +421,7 @@ export function Migration({
 			) : null}
 			{error ? (
 				<Surface>
-					<div className="surface-body">
+					<div className="surface-body form-stack">
 						<Notice tone="error">
 							{error}
 							{errorNoEffect
@@ -731,7 +732,7 @@ function UnlockStep({
 					<h2>Unlock locally and preview</h2>
 				</div>
 			</div>
-			<div className="surface-body">
+			<div className="surface-body form-stack">
 				{backend ? (
 					<Notice tone={backend.available ? "success" : "warning"}>
 						{backend.available
@@ -741,17 +742,13 @@ function UnlockStep({
 				) : (
 					<Spinner label="Checking Vault migration support" />
 				)}
-				<form onSubmit={onSubmit}>
-					<label className="field-label">
-						Source backup passphrase
-						<input
-							className="field"
-							type="password"
+				<form className="form-stack" onSubmit={onSubmit}>
+					<Field label="Source backup passphrase" htmlFor="source-passphrase">
+						<PasswordInput
+							id="source-passphrase"
 							value={sourcePassphrase}
-							onChange={(event) => setSourcePassphrase(event.target.value)}
+							onValueChange={setSourcePassphrase}
 							autoComplete="current-password"
-							pattern=".*\S.*"
-							title="Use at least one non-whitespace character."
 							aria-invalid={validationError ? true : undefined}
 							aria-describedby={
 								validationError ? "unlock-validation-error" : undefined
@@ -763,17 +760,16 @@ function UnlockStep({
 								pending !== undefined
 							}
 						/>
-					</label>
-					<label className="field-label">
-						Destination Vault passphrase
-						<input
-							className="field"
-							type="password"
+					</Field>
+					<Field
+						label="Destination Vault passphrase"
+						htmlFor="destination-passphrase"
+					>
+						<PasswordInput
+							id="destination-passphrase"
 							value={destinationPassphrase}
-							onChange={(event) => setDestinationPassphrase(event.target.value)}
+							onValueChange={setDestinationPassphrase}
 							autoComplete="new-password"
-							pattern=".*\S.*"
-							title="Use at least one non-whitespace character."
 							aria-invalid={validationError ? true : undefined}
 							aria-describedby={
 								validationError ? "unlock-validation-error" : undefined
@@ -785,7 +781,7 @@ function UnlockStep({
 								pending !== undefined
 							}
 						/>
-					</label>
+					</Field>
 					{validationError ? (
 						<div id="unlock-validation-error">
 							<Notice tone="error">{validationError}</Notice>
@@ -870,7 +866,7 @@ function PreviewStep({
 					{pending === "refresh" ? "Refreshing preview…" : "Refresh preview"}
 				</Button>
 			</div>
-			<div className="surface-body">
+			<div className="surface-body form-stack">
 				<Notice tone="info">{status}</Notice>
 				<div className="grid grid-two">
 					<div className="data-list">
@@ -948,16 +944,22 @@ function PreviewStep({
 				) : (
 					<p className="dim">No conflicts reported.</p>
 				)}
-				<label className="field-label">
-					Type <strong>MIGRATE_AND_SWITCH</strong> to authorize
-					<input
-						className="field"
+				<Field
+					label={
+						<>
+							Type <strong>MIGRATE_AND_SWITCH</strong> to authorize
+						</>
+					}
+					htmlFor="migrate-confirmation"
+				>
+					<TextInput
+						id="migrate-confirmation"
 						value={confirmation}
 						onChange={(event) => setConfirmation(event.target.value)}
 						autoComplete="off"
 						disabled={pending !== undefined}
 					/>
-				</label>
+				</Field>
 				<div className="form-actions">
 					<Button
 						onClick={onCutover}

--- a/src/views/features/VaultKeyPicker.tsx
+++ b/src/views/features/VaultKeyPicker.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import type { EmbeddedVaultKeyList } from "../../../utils/embeddedVaultIo";
+import {
+	Field,
+	PasswordInput,
+	SelectInput,
+	TextInput,
+} from "../components/FormFields";
 import { Button, Notice, Surface } from "../components/LocalShell";
+import { friendlySetupError } from "../lib/setupCopy";
 
 export function VaultKeyPicker({
 	token,
@@ -56,7 +63,9 @@ export function VaultKeyPicker({
 			}
 		} catch (error) {
 			setError(
-				error instanceof Error ? error.message : "Could not use this key.",
+				friendlySetupError(
+					error instanceof Error ? error.message : "Could not use this key.",
+				),
 			);
 		} finally {
 			setPending(false);
@@ -64,31 +73,28 @@ export function VaultKeyPicker({
 	}
 	return (
 		<Surface>
-			<div className="surface-body">
+			<div className="surface-body form-stack">
 				<h2>Use a key already in your Vault</h2>
 				<p>
 					Link an existing private key to a new wallet account, then assign it
 					to a role. This does not import another wallet’s transaction history.
 				</p>
-				{error && <Notice tone="error">{error}</Notice>}
+				{error ? <Notice tone="error">{error}</Notice> : null}
 				{!inventory ? (
-					<label className="field-label">
-						Vault password
-						<input
-							className="field"
-							type="password"
+					<Field label="Vault password" htmlFor="vault-key-password">
+						<PasswordInput
+							id="vault-key-password"
 							autoComplete="off"
 							value={password}
-							onChange={(event) => setPassword(event.target.value)}
+							onValueChange={setPassword}
 							disabled={pending}
 						/>
-					</label>
+					</Field>
 				) : (
 					<>
-						<label className="field-label">
-							Private key
-							<select
-								className="field"
+						<Field label="Private key" htmlFor="vault-private-key">
+							<SelectInput
+								id="vault-private-key"
 								value={entryId}
 								onChange={(event) => setEntryId(event.target.value)}
 								disabled={pending}
@@ -98,23 +104,24 @@ export function VaultKeyPicker({
 										{key.label} · {key.publicKey.slice(-8)}
 									</option>
 								))}
-							</select>
-						</label>
-						{!inventory.keys.length && (
+							</SelectInput>
+						</Field>
+						{!inventory.keys.length ? (
 							<Notice>
 								No compatible private keys found. HD roots and non-key entries
 								cannot be used directly.
 							</Notice>
-						)}
-						<label className="field-label">
-							Account name
-							<input
-								className="field"
+						) : null}
+						<Field label="Account name" htmlFor="vault-account-name">
+							<TextInput
+								id="vault-account-name"
 								value={name}
 								onChange={(event) => setName(event.target.value)}
 								disabled={pending}
+								autoComplete="off"
+								pattern="[a-z0-9][a-z0-9_-]{0,63}"
 							/>
-						</label>
+						</Field>
 					</>
 				)}
 				<div className="form-actions">

--- a/src/views/features/WalletRoleSettings.tsx
+++ b/src/views/features/WalletRoleSettings.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
-import { VaultKeyPicker } from "./VaultKeyPicker";
 import type {
 	WalletRole,
 	WalletRoleDefaults,
 } from "../../../utils/walletRoleDefaults";
+import { Field, SelectInput } from "../components/FormFields";
 import {
 	Button,
 	LocalShell,
@@ -11,6 +11,8 @@ import {
 	PageHeader,
 	Surface,
 } from "../components/LocalShell";
+import { defaultPaymentSelector, friendlySetupError } from "../lib/setupCopy";
+import { VaultKeyPicker } from "./VaultKeyPicker";
 
 const roles = [
 	{ id: "payments", label: "Payment key" },
@@ -26,10 +28,12 @@ type Settings = {
 };
 export function WalletRoleSettings({
 	token,
+	preferredAccount,
 	onBack,
 	onUnlock,
 }: {
 	token: string;
+	preferredAccount?: string;
 	onBack: () => void;
 	onUnlock: (account: string) => void;
 }) {
@@ -40,7 +44,7 @@ export function WalletRoleSettings({
 	const [showVaultKeys, setShowVaultKeys] = useState(false);
 	const [revision, setRevision] = useState(0);
 	useEffect(() => {
-		fetch("/api/embedded/roles", {
+		fetch(`/api/embedded/roles?revision=${revision}`, {
 			headers: { Authorization: `Bearer ${token}` },
 		})
 			.then(async (response) => {
@@ -48,7 +52,11 @@ export function WalletRoleSettings({
 				const value = await response.json();
 				setSettings(value);
 				setDefaults({
-					payments: value.defaults.payments ?? value.keys[0]?.selector ?? null,
+					payments: defaultPaymentSelector(
+						value.keys,
+						value.defaults.payments,
+						preferredAccount,
+					),
 					identity:
 						value.defaults.identity === undefined
 							? undefined
@@ -60,7 +68,7 @@ export function WalletRoleSettings({
 				});
 			})
 			.catch((error) => setError(error.message));
-	}, [token, revision]);
+	}, [token, revision, preferredAccount]);
 	async function save() {
 		if (!settings || pending) return;
 		setPending(true);
@@ -83,7 +91,9 @@ export function WalletRoleSettings({
 			onUnlock(value.effective.payments.split(":")[0]);
 		} catch (error) {
 			setError(
-				error instanceof Error ? error.message : "Could not save settings.",
+				friendlySetupError(
+					error instanceof Error ? error.message : "Could not save settings.",
+				),
 			);
 		} finally {
 			setPending(false);
@@ -96,7 +106,7 @@ export function WalletRoleSettings({
 				title="Choose your default keys"
 				description="Keep all your keys in one Vault. Choose which key each role uses; project MCP settings can override individual roles."
 			/>
-			{error && <Notice tone="error">{error}</Notice>}
+			{error ? <Notice tone="error">{error}</Notice> : null}
 			{showVaultKeys ? (
 				<VaultKeyPicker
 					token={token}
@@ -111,16 +121,31 @@ export function WalletRoleSettings({
 				</Button>
 			)}
 			<Surface>
-				<div className="surface-body">
+				<form
+					className="surface-body form-stack"
+					onSubmit={(event) => {
+						event.preventDefault();
+						void save();
+					}}
+				>
 					<p>
 						Import several wallets before unlocking. Choosing a default does not
-						move keys or funds.
+						move keys or funds. If more than one wallet is listed, choose the
+						one you just created or imported.
 					</p>
 					{roles.map((role) => (
-						<label className="field-label" key={role.id}>
-							{role.label}
-							<select
-								className="field"
+						<Field
+							label={role.label}
+							htmlFor={`role-${role.id}`}
+							key={role.id}
+							hint={
+								settings?.overrides.includes(role.id)
+									? `Project configuration overrides this role: ${settings.effective[role.id] ?? "disabled"}.`
+									: undefined
+							}
+						>
+							<SelectInput
+								id={`role-${role.id}`}
 								value={
 									defaults[role.id] === undefined
 										? "inherit"
@@ -148,24 +173,21 @@ export function WalletRoleSettings({
 										{key.selector} · {key.publicKey.slice(-8)}
 									</option>
 								))}
-							</select>
-							{settings?.overrides.includes(role.id) && (
-								<span className="source-detail">
-									Project configuration overrides this role:{" "}
-									{settings.effective[role.id] ?? "disabled"}.
-								</span>
-							)}
-						</label>
+							</SelectInput>
+						</Field>
 					))}
 					<div className="form-actions">
 						<Button variant="secondary" onClick={onBack} disabled={pending}>
 							Import more wallets
 						</Button>
-						<Button onClick={save} disabled={!settings || pending}>
+						<Button
+							type="submit"
+							disabled={!settings || pending || !defaults.payments}
+						>
 							Save defaults and unlock
 						</Button>
 					</div>
-				</div>
+				</form>
 			</Surface>
 		</LocalShell>
 	);

--- a/src/views/lib/setupCopy.test.ts
+++ b/src/views/lib/setupCopy.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import {
+	defaultPaymentSelector,
+	friendlySetupError,
+	unusedAccountName,
+} from "./setupCopy";
+
+test("unusedAccountName keeps a free name and remaps default when taken", () => {
+	expect(unusedAccountName("alice", [])).toBe("alice");
+	expect(unusedAccountName("default", ["default"])).toBe("imported-wallet");
+	expect(unusedAccountName("default", ["default", "imported-wallet"])).toBe(
+		"imported-wallet-2",
+	);
+	expect(unusedAccountName("alice", ["alice"])).toBe("alice-2");
+});
+
+test("defaultPaymentSelector prefers the wallet just created", () => {
+	const keys = [
+		{ selector: "default:payment" },
+		{ selector: "new-wallet:payment" },
+	];
+	expect(defaultPaymentSelector(keys, "default:payment", "new-wallet")).toBe(
+		"new-wallet:payment",
+	);
+	expect(defaultPaymentSelector(keys, "default:payment")).toBe(
+		"default:payment",
+	);
+	expect(defaultPaymentSelector(keys, undefined)).toBe(null);
+	expect(
+		defaultPaymentSelector([{ selector: "only:payment" }], undefined),
+	).toBe("only:payment");
+});
+
+test("friendlySetupError tells the user how to continue", () => {
+	expect(
+		friendlySetupError(
+			"The imported keys do not match the configured account address.",
+			"default",
+		),
+	).toContain("different wallet name");
+	expect(friendlySetupError("The vault binding does not match.")).toContain(
+		"different payment key",
+	);
+	expect(friendlySetupError("Enter your Vault password.")).toBe(
+		"Enter your Vault password.",
+	);
+});

--- a/src/views/lib/setupCopy.ts
+++ b/src/views/lib/setupCopy.ts
@@ -1,0 +1,47 @@
+/** Pick an unused wallet name when the source’s name is already saved. */
+export function unusedAccountName(
+	desired: string,
+	taken: readonly string[],
+): string {
+	if (!taken.includes(desired)) return desired;
+	const stem = desired === "default" ? "imported-wallet" : desired;
+	if (!taken.includes(stem)) return stem;
+	const maxStem = 60;
+	const clipped = stem.length > maxStem ? stem.slice(0, maxStem) : stem;
+	for (let n = 2; n < 100; n++) {
+		const candidate = `${clipped}-${n}`;
+		if (!taken.includes(candidate)) return candidate;
+	}
+	return `${clipped}-new`;
+}
+
+/** Prefill the payment key: the wallet just created, else the saved default, else the only key. */
+export function defaultPaymentSelector(
+	keys: Array<{ selector: string }>,
+	saved: string | null | undefined,
+	preferred?: string,
+): string | null {
+	if (preferred) {
+		const match = keys.find((key) => key.selector === `${preferred}:payment`);
+		if (match) return match.selector;
+	}
+	if (typeof saved === "string" && keys.some((key) => key.selector === saved))
+		return saved;
+	const payments = keys.filter((key) => key.selector.endsWith(":payment"));
+	if (payments.length === 1) return payments[0].selector;
+	return null;
+}
+
+/** Turn fail-closed backend errors into an action the user can take. */
+export function friendlySetupError(
+	message: string,
+	accountName?: string,
+): string {
+	if (message.includes("do not match the configured account address"))
+		return accountName
+			? `Those keys don’t match the saved wallet named ${accountName}. Choose a different wallet name to import them as a new wallet.`
+			: "Those keys don’t match a wallet already saved under that name. Choose a different wallet name.";
+	if (message.includes("vault binding does not match"))
+		return "This saved wallet doesn’t match the current Vault. Go back and choose a different payment key, or import the keys under a new name.";
+	return message;
+}

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -61,6 +61,7 @@ h3 { margin-bottom: 8px; font-size: 14px; }
 .button-secondary { border-color: var(--border); background: var(--elevated); color: var(--text); }
 .button-danger { background: var(--red); }
 .notice { border: 1px solid var(--border); border-radius: 7px; padding: 11px 13px; font-size: 13px; line-height: 1.45; }
+.local-content > .notice { margin-bottom: 16px; }
 .notice-info { background: #152028; border-color: #244050; color: #c4e5f1; }
 .notice-warning { background: #30250d; border-color: #5b4614; color: #fbd27d; }
 .notice-error { background: #321a1a; border-color: #663333; color: #ffc3c3; }
@@ -89,6 +90,26 @@ h3 { margin-bottom: 8px; font-size: 14px; }
 .field:focus, .select:focus { border-color: var(--cyan); box-shadow: 0 0 0 2px rgb(34 211 238 / 12%); }
 .field-label { display: grid; gap: 6px; color: var(--muted); font: 11px var(--mono); }
 .field-label + .field-label { margin-top: 13px; }
+.field-group { display: grid; gap: 8px; }
+.field-group > .field-label { display: block; margin: 0; }
+.field-hint, .field-error { margin: 0; font-size: 12px; line-height: 1.5; }
+.field-hint { color: var(--muted); }
+.field-error { color: var(--red); }
+.form-stack { display: grid; gap: 20px; }
+.form-stack > h2, .form-stack > p { margin-bottom: 0; }
+.password-field { position: relative; }
+.password-field .field { padding-right: 44px; }
+.password-toggle { position: absolute; inset: 0 0 0 auto; width: 44px; display: grid; place-items: center; border: 0; background: transparent; color: var(--muted); padding: 0; }
+.password-toggle:hover:not(:disabled) { color: var(--text); }
+.password-toggle:focus-visible { outline: 2px solid var(--primary); outline-offset: -4px; border-radius: 6px; }
+.hide-password-toggle::-ms-reveal, .hide-password-toggle::-ms-clear { display: none; }
+.checkbox-field { display: flex; align-items: flex-start; gap: 12px; }
+.checkbox-control { appearance: none; -webkit-appearance: none; width: 16px; height: 16px; margin: 3px 0 0; flex-shrink: 0; border: 1px solid var(--border); border-radius: 4px; background: var(--elevated); display: grid; place-content: center; }
+.checkbox-control:hover:not(:disabled) { border-color: var(--muted); }
+.checkbox-control:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+.checkbox-control:checked { background: var(--primary); border-color: var(--primary); }
+.checkbox-control:checked::after { content: ""; width: 10px; height: 10px; background: no-repeat center / contain url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23080808' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E"); }
+.checkbox-label { color: var(--text); font-size: 13px; line-height: 1.5; cursor: pointer; }
 .data-list { display: grid; gap: 0; border: 1px solid var(--border); border-radius: 7px; overflow: hidden; }
 .data-row { display: flex; justify-content: space-between; gap: 16px; border-bottom: 1px solid var(--border-subtle); padding: 11px 13px; }
 .data-row:last-child { border-bottom: 0; }
@@ -137,8 +158,9 @@ h3 { margin-bottom: 8px; font-size: 14px; }
 .setup-shell .local-header { min-height: 72px; padding-inline: 32px; background: transparent; }
 .setup-shell .brand-mark { font-family: inherit; font-size: 15px; gap: 12px; }
 .setup-shell .brand-symbol { width: 30px; height: 30px; }
-.setup-shell .local-content { width: min(100%, 736px); padding: 64px 28px 80px; }
-.setup-shell .page-header { margin-bottom: 32px; }
+.setup-shell .local-content { width: min(100%, 736px); padding: 64px 28px 80px; display: flex; flex-direction: column; gap: 24px; }
+.setup-shell .local-content > .notice { margin-bottom: 0; }
+.setup-shell .page-header { margin-bottom: 0; }
 .setup-shell .eyebrow { font-size: 13px; font-weight: 500; line-height: 1.5; letter-spacing: .04em; }
 .setup-shell .eyebrow > span { display: none; }
 .setup-shell h1 { font-size: clamp(30px, 5vw, 40px); line-height: 1.15; margin-bottom: 14px; font-weight: 600; }
@@ -160,7 +182,18 @@ h3 { margin-bottom: 8px; font-size: 14px; }
 .setup-shell .field, .setup-shell .select { min-height: 48px; padding: 12px 14px; font-size: 16px; border-radius: 9px; }
 .setup-shell .field-label { font-family: inherit; font-size: 15px; font-weight: 500; line-height: 1.5; gap: 10px; }
 .setup-shell .field-label + .field-label { margin-top: 24px; }
-.setup-shell .form-actions { align-items: center; gap: 16px; margin-top: 28px; margin-bottom: 24px; }
+.setup-shell .field-group { gap: 10px; }
+.setup-shell .field-hint, .setup-shell .field-error { font-size: 14px; line-height: 1.55; }
+.setup-shell .form-stack { gap: 24px; }
+.setup-shell .form-actions { align-items: center; gap: 16px; margin-top: 0; margin-bottom: 0; }
+.setup-shell .password-field .field { padding-right: 52px; }
+.setup-shell .password-toggle { width: 52px; color: var(--muted); }
+.setup-shell .password-toggle:focus-visible { border-radius: 9px; }
+.setup-shell .checkbox-control { width: 18px; height: 18px; margin-top: 3px; border-radius: 5px; }
+.setup-shell .checkbox-label { font-size: 15px; line-height: 1.55; }
+.setup-shell .choice-stack { display: grid; gap: 12px; }
+.setup-shell .local-content > .button { align-self: start; }
+.setup-shell input[type="file"].field { padding-block: 10px; font-size: 14px; }
 .setup-shell .notice { padding: 16px 18px; font-size: 15px; line-height: 1.6; }
 .setup-shell .migration-footnote { margin-top: 28px; font-size: 13px; line-height: 1.7; }
 .setup-shell .local-footer { justify-content: center; padding: 20px; letter-spacing: .06em; font-family: inherit; font-size: 11px; line-height: 1.5; }
@@ -189,12 +222,10 @@ h3 { margin-bottom: 8px; font-size: 14px; }
 .file-list li { font-size: 13px; line-height: 1.6; color: var(--muted); padding: 10px 0; border-top: 1px solid var(--border-subtle); }
 .setup-shell .source-meta p { margin-bottom: 0; }
 
-.wallet-source-choice { flex-direction: column; align-items: flex-start; gap: 5px; width: 100%; margin-block: 12px; padding: 20px 22px; }
+.wallet-source-choice { flex-direction: column; align-items: flex-start; gap: 5px; width: 100%; margin: 0; padding: 20px 22px; }
 .wallet-source-choice > span { display: block; color: var(--muted); font-size: 14px; line-height: 1.5; overflow-wrap: anywhere; }
 .wallet-source-choice > strong { font-size: 17px; }
 .wallet-source-choice + .field-label { margin-top: 24px; }
-.checkbox-field { display: flex; align-items: flex-start; gap: 10px; line-height: 1.5; }
-.checkbox-field input { margin-top: 5px; }
 
 .tool-cloud-section { position: relative; margin-top: 24px; text-align: center; }
 .tool-cloud-section h2 { font-size: 22px; letter-spacing: -.025em; }
@@ -230,7 +261,7 @@ h3 { margin-bottom: 8px; font-size: 14px; }
 .setup-shell:has(.wallet-ready) .local-header { border: 0; min-height: 84px; padding: 20px 3.2vw; }
 .setup-shell:has(.wallet-ready) .brand-mark { font-size: 19px; letter-spacing: .12em; }
 .setup-shell:has(.wallet-ready) .brand-symbol { width: 38px; height: 38px; font-style: normal; transform: none; color: #f2c969; border-color: #f2c969; }
-.setup-shell:has(.wallet-ready) .local-content { width: 100%; display: flex; padding: 0 3.2vw; }
+.setup-shell:has(.wallet-ready) .local-content { width: 100%; display: flex; padding: 0 3.2vw; gap: 0; }
 .wallet-ready { display: grid; grid-template-columns: .85fr 1.4fr; align-items: center; gap: 20px; width: 100%; min-height: calc(100dvh - 144px); }
 .ready-copy { padding-bottom: 35px; }
 .ready-check { display: grid; place-items: center; width: 48px; height: 48px; border: 2px solid #efc565; border-radius: 50%; color: #efc565; font-size: 30px; margin-bottom: 22px; }

--- a/utils/embeddedImportBackend.test.ts
+++ b/utils/embeddedImportBackend.test.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import { P1SAT_PROTOCOL } from "@1sat/actions";
 import { HD, PrivateKey, ProtoWallet, PublicKey } from "@bsv/sdk";
 import { encryptBackup } from "bitcoin-backup";
-import { readAccount, writeAccount } from "./accounts";
+import { newAccountConfig, readAccount, writeAccount } from "./accounts";
 import { createEmbeddedImportBackend } from "./embeddedImportBackend";
 import { SecureKeyManager } from "./keyManager";
 
@@ -553,6 +553,55 @@ describe.skipIf(!actual)("embedded import with real Vault files", () => {
 			readFileSync(join(sourceDir, "wallet-main.db")).equals(sourceDb),
 		).toBe(true);
 		expect(existsSync(join(root, "vault.bep"))).toBe(false);
+	});
+
+	it("imports a legacy root under a new name when default is already bound", async () => {
+		const root = freshRoot();
+		const home = join(root, "home");
+		writeLegacyRoot(home);
+		const destRoot = join(home, ".bsv-mcp", "accounts");
+		const other = PrivateKey.fromHex("98");
+		writeAccount(
+			"default",
+			{
+				...newAccountConfig("main", other.toAddress()),
+				vaultBinding: {
+					version: 1,
+					contract: "embedded-roots-v1",
+					vaultId: "other-vault",
+					payment: {
+						entryId: "pay",
+						publicKey: other.toPublicKey().toString(),
+					},
+				},
+			},
+			destRoot,
+		);
+		const backend = createEmbeddedImportBackend({
+			vaultPath: join(root, "vault.bep"),
+			home,
+			loadModule,
+		});
+		const occupied = {
+			source: {
+				account: "default",
+				location: "legacy-root" as const,
+				encryptedBackup: false,
+				plaintextKeys: true,
+				walletDatabases: ["wallet-main.db"],
+			},
+			password: VAULT_PASSWORD,
+			passwordConfirmation: VAULT_PASSWORD,
+			confirmation: "IMPORT_WALLET_CONFIRMED" as const,
+		};
+		await expect(backend.import(occupied)).rejects.toThrow("do not match");
+		const result = await backend.import({
+			...occupied,
+			accountName: "imported-wallet",
+		});
+		expect(result.accountName).toBe("imported-wallet");
+		expect(result.address).toBe(PAY.toAddress());
+		expect(readAccount("default", destRoot)?.address).toBe(other.toAddress());
 	});
 
 	it("writes nothing for a wrong source passphrase", async () => {

--- a/utils/embeddedImportBackend.ts
+++ b/utils/embeddedImportBackend.ts
@@ -50,6 +50,8 @@ export interface EmbeddedImportInput {
 	passwordConfirmation?: string;
 	sourcePassphrase?: string;
 	confirmation: typeof IMPORT_CONFIRMATION;
+	/** Optional destination account when the source name is already taken. */
+	accountName?: string;
 }
 
 export interface EmbeddedImportBackupInput {
@@ -204,6 +206,7 @@ function selectTrustedSource(
 	home: string,
 	destRoot: string,
 	vaultPath: string,
+	destNameOverride?: string,
 ): TrustedSelection {
 	const account =
 		typeof source?.account === "string" ? source.account : undefined;
@@ -232,11 +235,15 @@ function selectTrustedSource(
 			candidate.account === account && candidate.location === location,
 	);
 	if (!entry) throw failure("UNKNOWN_SOURCE", MESSAGES.UNKNOWN_SOURCE);
-	// Destination name is authoritative inventory state. Legacy and lab
-	// entries already carry their canonical account names.
-	const destName = entry.account;
+	const destName =
+		destNameOverride === undefined ? entry.account : destNameOverride;
 	if (accountNameSchema.safeParse(destName).success !== true)
-		throw failure("UNKNOWN_SOURCE", MESSAGES.UNKNOWN_SOURCE);
+		throw failure(
+			destNameOverride === undefined ? "UNKNOWN_SOURCE" : "ACCOUNT_INVALID",
+			destNameOverride === undefined
+				? MESSAGES.UNKNOWN_SOURCE
+				: MESSAGES.ACCOUNT_INVALID,
+		);
 	const sourceDir = entry.directory;
 	if (
 		(location === "environment" || location === "mcp-client") &&
@@ -906,6 +913,7 @@ export function createEmbeddedImportBackend(
 			home,
 			destRoot,
 			vaultPath,
+			input.accountName,
 		);
 		// Confirmation is enforced before any private material is read or
 		// any byte is written. Inventory above inspects filenames only.

--- a/utils/embeddedSetupActions.ts
+++ b/utils/embeddedSetupActions.ts
@@ -179,14 +179,13 @@ export function createEmbeddedSetupActions(options: {
 						backupName: input.backupName ?? "backup",
 					});
 				} else {
-					if (!input.source || input.source.account !== input.accountName)
-						throw new Error(
-							"Choose the original account name for this local wallet.",
-						);
+					if (!input.source)
+						throw new Error("Choose a local wallet to import.");
 					saved = await importer.import({
 						source: input.source as Parameters<
 							typeof importer.import
 						>[0]["source"],
+						accountName: input.accountName,
 						password: input.destinationPassphrase,
 						passwordConfirmation: input.passwordConfirmation,
 						sourcePassphrase: input.sourcePassphrase,


### PR DESCRIPTION
## Problem
First-run setup unlocked leftover `default` after creating or importing another wallet, so Vault binding failed. Importing an existing keys.json into that occupied name was refused. Setup forms used raw inputs and native checkboxes, with errors sitting against adjacent fields.

## Change
Prefer the wallet just created or imported as the payment key. Allow import under a free account name when the source name is already bound. Add labeled form fields, password visibility toggles, and checkboxes, and space errors so they do not touch other controls.

## Risk
Setup-only. Existing unlocked wallets and tool APIs are unchanged.