### PR TITLE
Clarify the leftover client-key welcome notice

### DIFF
--- a/src/views/features/FirstRun.tsx
+++ b/src/views/features/FirstRun.tsx
@@ -277,8 +277,8 @@ export function FirstRun({
 				<div className="setup-choices">
 					{foundClientKeys ? (
 						<Notice>
-							A payment key is still in an MCP client config. Choose “Use an
-							existing wallet” to import it into Vault.
+							An AI client on this computer still has a payment key in its
+							settings. Import it into Vault rather than leaving it there.
 						</Notice>
 					) : null}
 					{(boundAccounts.length > 0 || vaultExists) && (

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -194,7 +194,7 @@ h3 { margin-bottom: 8px; font-size: 14px; }
 .setup-shell .choice-stack { display: grid; gap: 12px; }
 .setup-shell .local-content > .button { align-self: start; }
 .setup-shell input[type="file"].field { padding-block: 10px; font-size: 14px; }
-.setup-shell .notice { padding: 16px 18px; font-size: 15px; line-height: 1.6; }
+.setup-shell .notice { padding: 16px 18px; font-size: 15px; line-height: 1.6; text-wrap: pretty; }
 .setup-shell .migration-footnote { margin-top: 28px; font-size: 13px; line-height: 1.7; }
 .setup-shell .local-footer { justify-content: center; padding: 20px; letter-spacing: .06em; font-family: inherit; font-size: 11px; line-height: 1.5; }
 .setup-shell button:focus-visible, .setup-shell summary:focus-visible { outline: 2px solid var(--primary); outline-offset: 4px; }


### PR DESCRIPTION
## Problem
The welcome banner “A payment key is still in an MCP client config…” is hard to parse, and the quoted button name forces the last couple of words onto their own line.

## Change
Say that an AI client still has a payment key in its settings and to import it into Vault. Wrap setup notices with pretty line breaks.

## Risk
Copy and wrapping only on the first-run welcome notice.