### PR TITLE
Bump plugin manifest version to 0.6.3 [OPL-4679]

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "bsv-mcp",
 	"version": "0.6.3",
-	"description": "Bitcoin SV MCP server with interactive dashboard \u2014 Explorer, Wallet, and Ordinals tabs via MCP Apps. Tools for price lookup, transaction decoding, address lookup, wallet management, NFT marketplace, and identity.",
+	"description": "Bitcoin SV MCP server with interactive dashboard — Explorer, Wallet, and Ordinals tabs via MCP Apps. Tools for price lookup, transaction decoding, address lookup, wallet management, NFT marketplace, and identity.",
 	"author": {
 		"name": "rohenaz",
 		"url": "https://github.com/rohenaz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "bsv-mcp",
-	"version": "0.6.1",
+	"version": "0.6.3",
 	"description": "Bitcoin SV tools for AI assistants. Run a local MCP server with your own wallet.",
 	"author": {
 		"name": "bOpen",


### PR DESCRIPTION
## Problem
Codex and Claude Code cache installed plugins by the manifest version string. The icon change merged today did not bump the version, so existing installs never see it.

## Change
Bump .codex-plugin and .claude-plugin manifest versions to 0.6.3.

Part of OPL-4679.

https://claude.ai/code/session_01FQPcoUWn3CKjzWbqpaf5HA